### PR TITLE
Fix: Input System未導入環境でInputSystemHandlerTestsが失敗する問題

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/Tests/Editor/UnityMCPServer.Tests.asmdef
+++ b/UnityMCPServer/Packages/unity-mcp-server/Tests/Editor/UnityMCPServer.Tests.asmdef
@@ -20,6 +20,12 @@
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "",
+            "define": "UNITY_INPUT_SYSTEM_PACKAGE"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
## 概要\n- Input Systemが導入されていない環境でEditorテストがクラッシュする問題を修正\n- InputSystemHandlerTestsを安全なデバイスクリーンアップと未導入時のスキップに対応\n- UnityMCPServer.Testsアセンブリにversion defineを追加してInput System導入時のみテストをコンパイル\n\n## 動作確認\n- MCP test_run(EditMode, filter="InputSystemHandlerTests")],

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Tests**
  * 入力システムテストの堅牢性を向上し、デバイスの安全な初期化とクリーンアップを改善しました。

* **Chores**
  * 入力システムパッケージの条件付きコンパイル定義を追加し、パッケージの可用性に応じた柔軟な対応を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->