### PR TITLE
chore(release): v2.17.0へマイナーバージョンアップ

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/package.json
+++ b/UnityMCPServer/Packages/unity-mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.akiojin.unity-mcp-server",
   "displayName": "Unity MCP Server",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "unity": "6000.0",
   "description": "Unity Editor MCP bridge and tooling for AI-assisted development (screenshots, video capture, scene analysis, input automation).",
   "keywords": [

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akiojin/unity-mcp-server",
-  "version": "2.16.3",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akiojin/unity-mcp-server",
-      "version": "2.16.3",
+      "version": "2.17.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@akiojin/unity-mcp-server",
-  "version": "2.16.3",
-  "description": "MCP server and Unity Editor bridge \u2014 enables AI assistants to control Unity for AI-assisted workflows",
+  "version": "2.17.0",
+  "description": "MCP server and Unity Editor bridge — enables AI assistants to control Unity for AI-assisted workflows",
   "type": "module",
   "main": "src/core/server.js",
   "bin": {


### PR DESCRIPTION
## 変更内容

- mcp-server: 2.16.3 → 2.17.0
- Unity package: 2.16.3 → 2.17.0

マイナーバージョンアップを実行しました。

## チェックリスト

- [x] npm version minorを実行
- [x] Unity packageのバージョン同期
- [x] コミット＆プッシュ
- [ ] テスト実行（CI）
- [ ] npm publish（マージ後）