### PR TITLE
feat(ci): release.ymlに手動トリガー機能を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## 変更内容

release.yml ワークフローに `workflow_dispatch` トリガーを追加しました。

## 理由

- ワークフローファイルを含むコミットでは、初回はワークフローがトリガーされないことがあるため
- GitHub UI から手動でリリースワークフローを実行できるようにするため
- 初回リリースやテスト時に有用

## テスト計画

- PRマージ後、GitHub UI から Release ワークフローを手動実行
- semantic-release が正常に動作することを確認