### PR TITLE
fix(release): GitHub Release資産に一意の名前を付与

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -29,10 +29,12 @@
         "assets": [
           {
             "path": "mcp-server/package.json",
+            "name": "mcp-server-package.json",
             "label": "mcp-server package.json"
           },
           {
             "path": "UnityMCPServer/Packages/unity-mcp-server/package.json",
+            "name": "unity-package.json",
             "label": "Unity Package package.json"
           },
           {


### PR DESCRIPTION
## 問題

GitHub Release に資産を添付する際、2つの `package.json` ファイルが同じ名前で競合していました。

```
Validation Failed: {"resource":"ReleaseAsset","code":"already_exists","field":"name"}
```

## 解決策

各資産に `name` フィールドを追加して、一意の名前を付与しました。

### 変更内容

- `mcp-server/package.json` → `mcp-server-package.json`
- `UnityMCPServer/Packages/unity-mcp-server/package.json` → `unity-package.json`
- `CHANGELOG.md` （そのまま）

これにより、GitHub Release に3つの異なる名前の資産が添付されます。