### PR TITLE
fix(ci): semantic-release後にタグをpush

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
+
+      - name: Push tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push --tags https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}


### PR DESCRIPTION
## 問題

semantic-release はタグを作成しますが、リモートにpushしません。そのため、csharp-lsp ビルドワークフローがトリガーされませんでした。

## 解決策

Release ワークフローに「Push tags」ステップを追加しました。

### 変更内容

- semantic-release 実行後にタグを push
- `GITHUB_TOKEN` を使用して安全に push
- csharp-lsp ビルドワークフローがタグ push でトリガーされる

### リリースフロー（完全版）

1. semantic-release 実行 → GitHub Release 作成
2. **タグ push** → csharp-lsp ビルドトリガー
3. csharp-lsp ビルド完了 → バイナリを Release に添付
4. Release 公開イベント → npm publish トリガー