### PR TITLE
fix: 設定自動生成とproject.root検証を追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": ["standard"],
   "env": {
     "node": true,

--- a/mcp-server/tests/unit/core/projectInfo.test.js
+++ b/mcp-server/tests/unit/core/projectInfo.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { ProjectInfoProvider } from '../../../src/core/projectInfo.js';
+import { config } from '../../../src/core/config.js';
 
 describe('ProjectInfoProvider', () => {
   let provider;
@@ -57,6 +58,23 @@ describe('ProjectInfoProvider', () => {
     it('should provide project info functionality', () => {
       assert.ok(ProjectInfoProvider);
       assert.equal(typeof ProjectInfoProvider, 'function');
+    });
+  });
+
+  describe('configuration requirements', () => {
+    it('should throw when project.root is configured but empty', async () => {
+      const originalProject = { ...config.project };
+      config.project = { ...(config.project || {}), root: '' };
+
+      try {
+        const provider = new ProjectInfoProvider({
+          isConnected: () => false,
+          sendCommand: async () => ({})
+        });
+        await assert.rejects(() => provider.get(), /project\.root is configured but empty/);
+      } finally {
+        config.project = originalProject;
+      }
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/github": "^10.0.0",
         "@semantic-release/release-notes-generator": "^12.1.0",
-        "husky": "^9.1.7",
         "semantic-release": "^22.0.12"
       }
     },
@@ -47,6 +46,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.6.0",
+        "husky": "^9.1.7",
         "markdownlint-cli": "^0.43.0",
         "nodemon": "^3.1.7",
         "prettier": "^3.4.2",


### PR DESCRIPTION
## Summary
- create a default .unity/config.json when missing (localhost endpoints + inferred project root)
- require explicit project.root instead of docker fallback
- add targeted unit tests covering config generation and project root validation

## Testing
- node --test tests/unit/core/config.test.js tests/unit/core/projectInfo.test.js
- npm run test:ci


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 設定ファイル生成時の処理を最適化し、デフォルト設定の作成ロジックを改善しました。
  * プロジェクトルート設定の検証ロジックをより厳密にしました。

* **Tests**
  * 設定ファイル生成とプロジェクト設定検証のテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->