### PR TITLE
release: v2.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,36 @@ This project uses [semantic-release](https://semantic-release.gitbook.io/) with 
 
 **Note**: Testing automated release workflow.
 
-#### How It Works
+#### Three-Tier Release Flow (feature → develop → main)
+
+This project implements a **three-tier release workflow** for controlled and predictable releases:
+
+1. **Feature Development** (feature branches)
+   - Create feature branch: `feature/SPEC-xxxxxxxx`
+   - Commit with Conventional Commits
+   - Run `finish-feature.sh` → auto-create PR to `develop`
+
+2. **Integration Stage** (`develop` branch)
+   - Required checks pass → auto-merge to `develop`
+   - Multiple features accumulate in `develop`
+   - No releases triggered from `develop`
+
+3. **Production Release** (`main` branch)
+   - Run `/release` command → create `develop` → `main` PR
+   - Required checks pass → auto-merge to `main`
+   - **semantic-release auto-executes**: version bump, CHANGELOG, tag creation
+   - **csharp-lsp Build**: all platforms → GitHub Release
+   - **npm Publish**: MCPサーバー → npmjs.com
+
+**Benefits**:
+- 🎯 Controlled release timing (manual `/release` trigger)
+- 🔄 Multiple features can be bundled into one release
+- 🛡️ `develop` acts as integration/staging before production
+- 📦 Single version across all components (mcp-server, Unity Package, csharp-lsp)
+
+#### How It Works (Legacy Two-Tier)
+
+The previous two-tier flow (feature → main) is deprecated:
 
 1. **Developer**: Create feature branch, commit with Conventional Commits, create PR
 2. **Auto-Merge**: Required checks pass → automatic merge to `main`


### PR DESCRIPTION
## 🚀 リリース: v2.18.0

このPRは、developブランチの変更をmainブランチにリリースします。

---

## 📋 リリース内容

4f3836b feat: Add three-tier release workflow (feature → develop → main)
56fb1d0 Merge pull request #32 from akiojin/feature/auto-release
4f21fbb chore: 自動リリースフローのテスト

---

## 🎯 リリースノート

### [2.18.0] (2025-11-07)

#### Features
* Add three-tier release workflow (feature → develop → main)
  - Controlled release timing with manual `/release` trigger
  - Multiple features can be bundled into one release
  - `develop` acts as integration/staging before production
  - Single version across all components

#### Chores
* 自動リリースフローのテスト

---

## 🤖 自動リリースフロー

このPRをマージすると、以下が自動的に実行されます：

1. **semantic-release**: package.json（2.17.0 → 2.18.0）、Unity Package、CHANGELOG.mdを更新、タグ作成（v2.18.0）
2. **GitHub Release**: リリースノートと共にリリース作成
3. **npm publish**: MCPサーバーをnpmjs.comに公開（@akiojin/unity-mcp-server@2.18.0）
4. **LSPサーバービルド**: 全プラットフォーム（linux-x64, osx-x64, osx-arm64, win-x64）でビルド、GitHub Releaseに添付

---

⚠️ **重要**: このPRはRequiredチェック成功後に手動マージしてください。

📝 **仕様**: 3層リリースフロー（feature → develop → main）