### PR TITLE
release: v2.25.1

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -24,6 +24,18 @@
       }
     ],
     [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "mcp-server/package.json",
+          "mcp-server/package-lock.json",
+          "CHANGELOG.md",
+          "UnityMCPServer/Packages/unity-mcp-server/package.json"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "assets": [


### PR DESCRIPTION
## 🚀 リリース: v2.25.1

このPRは、developブランチの変更をmainブランチにリリースします。

---

## 📋 リリース内容

4758b5c fix: Add @semantic-release/git plugin to commit version changes

---

## 🎯 リリースノート

### [2.25.1] (2025-11-07)

#### Fixes
* Add @semantic-release/git plugin to commit version changes
  - semantic-releaseでpackage.json、Unity Package、CHANGELOGの更新を自動的にコミット
  - npm publishワークフローのバージョン不一致エラーを修正

---

## 🤖 自動リリースフロー

このPRをマージすると、以下が自動的に実行されます：

1. **semantic-release**: package.json（2.25.0 → 2.25.1）、Unity Package、CHANGELOG.mdを更新、タグ作成（v2.25.1）
2. **@semantic-release/git**: 上記の変更をmainブランチに自動コミット（[skip ci]付き）
3. **GitHub Release**: リリースノートと共にリリース作成
4. **npm publish**: MCPサーバーをnpmjs.comに公開（@akiojin/unity-mcp-server@2.25.1）
5. **LSPサーバービルド**: 全プラットフォーム（linux-x64, osx-x64, osx-arm64, win-x64）でビルド、GitHub Releaseに添付

---

⚠️ **重要**: このPRはRequiredチェック成功後に自動的にmainへマージされます。

📝 **修正内容**: @semantic-release/gitプラグイン追加により、リリース時のバージョン更新が正しくコミットされるようになります。