### PR TITLE
ci: releaseワークフローをpnpm対応

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,14 +19,21 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run semantic-release dry-run
         id: version
@@ -35,7 +42,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # semantic-release dry-runを実行してバージョン番号を取得
-          OUTPUT=$(npx semantic-release --dry-run --branches develop 2>&1)
+          OUTPUT=$(pnpm exec semantic-release --dry-run --branches develop 2>&1)
           echo "$OUTPUT"
 
           # バージョン番号を抽出

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,21 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run semantic-release
         id: semantic
@@ -56,7 +63,7 @@ jobs:
           HUSKY: 0
         run: |
           # semantic-releaseを実行して出力を取得
-          npx semantic-release > release-output.txt 2>&1
+          pnpm exec semantic-release > release-output.txt 2>&1
           RELEASE_EXIT_CODE=$?
           cat release-output.txt
 


### PR DESCRIPTION
## 概要
- create-release.yml / release.yml がnpm前提だったため、pnpm/action-setupとpnpm installへ移行
- semantic-release実行もpnpm exec経由に変更し、リリースブランチ作成/semantic-release本番がpnpmロックファイルを参照できるようにした

## テスト
- pnpm install --frozen-lockfile
- pnpm exec commitlint --from HEAD~1 --to HEAD
- git push 時の pre-push フック (npm run test:ci)
