### PR TITLE
chore: semantic-releaseプリセットを修正

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,5 +1,7 @@
 const { parserPreset, releaseRules } = require('./configs/commit-convention.cjs')
 
+const SEMREL_PRESET = 'conventionalcommits'
+
 module.exports = {
   branches: [
     {
@@ -12,7 +14,7 @@ module.exports = {
     [
       '@semantic-release/commit-analyzer',
       {
-        preset: parserPreset.name,
+        preset: SEMREL_PRESET,
         releaseRules,
         parserOpts: parserPreset.parserOpts
       }
@@ -20,7 +22,7 @@ module.exports = {
     [
       '@semantic-release/release-notes-generator',
       {
-        preset: parserPreset.name,
+        preset: SEMREL_PRESET,
         parserOpts: parserPreset.parserOpts
       }
     ],


### PR DESCRIPTION
## 概要
- semantic-releaseのpreset指定が二重prefixになっていたためdry-runでMODULE_NOT_FOUNDが発生
- presetは`conventionalcommits`に固定しつつ、parserOptsとreleaseRulesは共通設定を利用

## テスト
- pnpm exec semantic-release --dry-run --branches develop
- pnpm exec commitlint --from HEAD~1 --to HEAD
- git push 時の pre-push フック (npm run test:ci)
