### PR TITLE
chore: npm workspace設定を追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+workspaces=true
+workspaces-update=false


### PR DESCRIPTION
## 概要
- npm@10 の workspace バグで `npm version` がこけるため、.npmrc に `workspaces=true` / `workspaces-update=false` を追加
- semantic-releaseのnpmプラグインが`npm version`を実行するときにエラーを回避

## テスト
- pnpm exec semantic-release --dry-run --branches develop
- pnpm exec commitlint --from HEAD~1 --to HEAD
- git push 時の pre-push フック (npm run test:ci)
