### PR TITLE
Fix play mode warnings and execution gating

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/Editor/Handlers/TestExecutionHandler.cs
+++ b/UnityMCPServer/Packages/unity-mcp-server/Editor/Handlers/TestExecutionHandler.cs
@@ -24,6 +24,7 @@ namespace UnityMCPServer.Handlers
         private static TestResultCollector currentCollector;
         private static bool isTestRunning;
         internal static Func<bool> DirtySceneDetector = DetectDirtyScenes;
+        internal static Func<bool> PlayModeDetector = () => Application.isPlaying;
         private static readonly string DefaultResultsFolder = Path.GetFullPath(Path.Combine(Application.dataPath, "../.unity/test-results"));
         private static string lastResultPath;
         private static JObject lastResultSummary;
@@ -61,6 +62,11 @@ namespace UnityMCPServer.Handlers
                 if (testMode != "EditMode" && testMode != "PlayMode" && testMode != "All")
                 {
                     return new { error = "Invalid testMode. Must be EditMode, PlayMode, or All" };
+                }
+
+                if (PlayModeDetector?.Invoke() ?? Application.isPlaying)
+                {
+                    return new { error = "Cannot run tests while Play Mode is active. Exit Play Mode before running tests." };
                 }
 
                 if (DirtySceneDetector())
@@ -317,6 +323,7 @@ namespace UnityMCPServer.Handlers
         internal static void ResetForTesting()
         {
             DirtySceneDetector = DetectDirtyScenes;
+            PlayModeDetector = () => Application.isPlaying;
             lastResultPath = null;
             lastResultSummary = null;
             lastResultTimestampUtc = null;

--- a/UnityMCPServer/Packages/unity-mcp-server/Tests/Editor/Handlers/TestExecutionHandlerTests.cs
+++ b/UnityMCPServer/Packages/unity-mcp-server/Tests/Editor/Handlers/TestExecutionHandlerTests.cs
@@ -50,6 +50,25 @@ namespace UnityMCPServer.Tests
         }
 
         [Test]
+        public void RunTests_ShouldFailDuringPlayMode()
+        {
+            try
+            {
+                TestExecutionHandler.PlayModeDetector = () => true;
+
+                var result = TestExecutionHandler.RunTests(new JObject()) as dynamic;
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.error);
+                StringAssert.Contains("Play Mode", (string)result.error);
+            }
+            finally
+            {
+                TestExecutionHandler.ResetForTesting();
+            }
+        }
+
+        [Test]
         public void RunTests_ShouldFailIfAlreadyRunning()
         {
             // Note: This test would be difficult to implement reliably

--- a/mcp-server/tests/integration/playmode/playmode-flow.test.js
+++ b/mcp-server/tests/integration/playmode/playmode-flow.test.js
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PlaymodePlayToolHandler } from '../../../src/handlers/playmode/PlaymodePlayToolHandler.js';
+import { PlaymodeStopToolHandler } from '../../../src/handlers/playmode/PlaymodeStopToolHandler.js';
+
+class FakeUnityConnection {
+  constructor() {
+    this.connected = true;
+    this.isPlaying = false;
+    this.playCountdown = 0;
+    this.stopCountdown = 0;
+    this.sendLog = [];
+  }
+
+  isConnected() {
+    return this.connected;
+  }
+
+  async connect() {
+    this.connected = true;
+  }
+
+  async sendCommand(type) {
+    this.sendLog.push(type);
+    switch (type) {
+      case 'play_game':
+        this.playCountdown = 1; // require one poll cycle before playing
+        return { status: 'success', message: 'Play requested' };
+      case 'stop_game':
+        this.stopCountdown = 1; // require one poll cycle before stopping
+        return { status: 'success', message: 'Stop requested' };
+      case 'get_editor_state':
+        if (this.playCountdown > 0) {
+          this.playCountdown--;
+          if (this.playCountdown === 0) {
+            this.isPlaying = true;
+          }
+        }
+        if (this.stopCountdown > 0) {
+          this.stopCountdown--;
+          if (this.stopCountdown === 0) {
+            this.isPlaying = false;
+          }
+        }
+        return {
+          status: 'success',
+          state: {
+            isPlaying: this.isPlaying,
+            isPaused: false,
+            isCompiling: false,
+            timeSinceStartup: 0
+          }
+        };
+      default:
+        throw new Error(`Unexpected command ${type}`);
+    }
+  }
+}
+
+describe('Play Mode end-to-end flow (handlers)', () => {
+  it('should enter and exit Play Mode using the tool handlers', async () => {
+    const unityConnection = new FakeUnityConnection();
+    const playHandler = new PlaymodePlayToolHandler(unityConnection);
+    const stopHandler = new PlaymodeStopToolHandler(unityConnection);
+
+    const playResult = await playHandler.execute({ pollIntervalMs: 0, maxWaitMs: 2000 });
+    assert.equal(playResult.status, 'success');
+    assert.equal(playResult.state.isPlaying, true);
+    assert.ok(unityConnection.sendLog.includes('play_game'));
+
+    const stopResult = await stopHandler.execute({ pollIntervalMs: 0, maxWaitMs: 2000 });
+    assert.equal(stopResult.status, 'success');
+    assert.equal(stopResult.state.isPlaying, false);
+    assert.ok(unityConnection.sendLog.includes('stop_game'));
+  });
+});

--- a/mcp-server/tests/unit/handlers/playmode/PlaymodePlayToolHandler.test.js
+++ b/mcp-server/tests/unit/handlers/playmode/PlaymodePlayToolHandler.test.js
@@ -1,26 +1,68 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { PlaymodePlayToolHandler } from '../../../../src/handlers/playmode/PlaymodePlayToolHandler.js';
-import { createMockUnityConnection } from '../../../utils/test-helpers.js';
 
 describe('PlaymodePlayToolHandler', () => {
-  let handler;
-  let mockConnection;
+  const createHandler = sendCommand =>
+    new PlaymodePlayToolHandler({
+      isConnected: () => true,
+      connect: mock.fn(async () => {}),
+      sendCommand
+    });
 
-  beforeEach(() => {
-    mockConnection = createMockUnityConnection({ sendCommandResult: { success: true } });
-    handler = new PlaymodePlayToolHandler(mockConnection);
+  it('should poll get_editor_state until isPlaying becomes true', async () => {
+    let pollCount = 0;
+    const sendCommand = mock.fn(async type => {
+      if (type === 'play_game') {
+        return { status: 'success', message: 'scheduled' };
+      }
+      if (type === 'get_editor_state') {
+        pollCount++;
+        return {
+          status: 'success',
+          state: { isPlaying: pollCount >= 2 }
+        };
+      }
+      throw new Error(`Unexpected command: ${type}`);
+    });
+
+    const handler = createHandler(sendCommand);
+    const result = await handler.execute({ pollIntervalMs: 0 });
+
+    assert.equal(result.status, 'success');
+    assert.equal(result.state.isPlaying, true);
+    assert.ok(pollCount >= 2);
+    assert.equal(sendCommand.mock.calls[0].arguments[0], 'play_game');
+    assert.ok(sendCommand.mock.calls.some(call => call.arguments[0] === 'get_editor_state'));
   });
 
-  describe('constructor', () => {
-    it('should initialize with correct name', () => {
-      assert.equal(handler.name, 'playmode_play');
+  it('should accept editor state delivered via _editorState', async () => {
+    let returnedPlaying = false;
+    const sendCommand = mock.fn(async type => {
+      if (type === 'play_game') {
+        return { status: 'success', message: 'entered' };
+      }
+      if (type === 'get_editor_state') {
+        if (!returnedPlaying) {
+          returnedPlaying = true;
+          return { status: 'success', state: { isPlaying: false } };
+        }
+        return {
+          status: 'success',
+          _editorState: { isPlaying: true }
+        };
+      }
+      throw new Error(`Unexpected command: ${type}`);
     });
-  });
 
-  describe('SPEC compliance', () => {
-    it('should enter play mode', () => {
-      assert.equal(handler.name, 'playmode_play');
-    });
+    const handler = createHandler(sendCommand);
+    const result = await handler.execute({ pollIntervalMs: 0 });
+
+    assert.equal(result.status, 'success');
+    assert.equal(result.state.isPlaying, true);
+    const getStateCalls = sendCommand.mock.calls.filter(
+      call => call.arguments[0] === 'get_editor_state'
+    ).length;
+    assert.ok(getStateCalls >= 2);
   });
 });

--- a/mcp-server/tests/unit/handlers/playmode/PlaymodeStopToolHandler.test.js
+++ b/mcp-server/tests/unit/handlers/playmode/PlaymodeStopToolHandler.test.js
@@ -1,26 +1,62 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { PlaymodeStopToolHandler } from '../../../../src/handlers/playmode/PlaymodeStopToolHandler.js';
-import { createMockUnityConnection } from '../../../utils/test-helpers.js';
 
 describe('PlaymodeStopToolHandler', () => {
-  let handler;
-  let mockConnection;
+  const createHandler = sendCommand =>
+    new PlaymodeStopToolHandler({
+      isConnected: () => true,
+      connect: mock.fn(async () => {}),
+      sendCommand
+    });
 
-  beforeEach(() => {
-    mockConnection = createMockUnityConnection({ sendCommandResult: { success: true } });
-    handler = new PlaymodeStopToolHandler(mockConnection);
+  it('should poll get_editor_state until play mode stops', async () => {
+    let pollCount = 0;
+    const sendCommand = mock.fn(async type => {
+      if (type === 'stop_game') {
+        return { status: 'success', message: 'Stopping' };
+      }
+      if (type === 'get_editor_state') {
+        pollCount++;
+        return {
+          status: 'success',
+          state: { isPlaying: pollCount < 2 }
+        };
+      }
+      throw new Error(`Unexpected command: ${type}`);
+    });
+
+    const handler = createHandler(sendCommand);
+    const result = await handler.execute({ pollIntervalMs: 0 });
+
+    assert.equal(result.status, 'success');
+    assert.equal(result.state.isPlaying, false);
+    assert.equal(result.message, 'Stopping');
+    assert.ok(sendCommand.mock.calls.some(call => call.arguments[0] === 'stop_game'));
+    assert.ok(sendCommand.mock.calls.some(call => call.arguments[0] === 'get_editor_state'));
   });
 
-  describe('constructor', () => {
-    it('should initialize with correct name', () => {
-      assert.equal(handler.name, 'playmode_stop');
+  it('should accept editor state delivered via _editorState', async () => {
+    let first = true;
+    const sendCommand = mock.fn(async type => {
+      if (type === 'stop_game') {
+        return { status: 'success', message: 'Done' };
+      }
+      if (type === 'get_editor_state') {
+        if (first) {
+          first = false;
+          return { status: 'success', state: { isPlaying: true } };
+        }
+        return { status: 'success', _editorState: { isPlaying: false } };
+      }
+      throw new Error(`Unexpected command: ${type}`);
     });
-  });
 
-  describe('SPEC compliance', () => {
-    it('should exit play mode', () => {
-      assert.equal(handler.name, 'playmode_stop');
-    });
+    const handler = createHandler(sendCommand);
+    const result = await handler.execute({ pollIntervalMs: 0 });
+
+    assert.equal(result.status, 'success');
+    assert.equal(result.state.isPlaying, false);
+    assert.equal(result.message, 'Done');
   });
 });


### PR DESCRIPTION
## Summary
- add runtime warning helper coverage and warn set_component_field
- block test execution in Play Mode and add warning-appending logic
- stabilize playmode_play/stop handlers with get_editor_state polling and new tests

## Testing
- node --test tests/unit/handlers/PlaymodePlayToolHandler.test.js tests/unit/handlers/PlaymodeStopToolHandler.test.js
- node --test tests/unit/handlers/playmode/PlaymodePlayToolHandler.test.js tests/unit/handlers/playmode/PlaymodeStopToolHandler.test.js
- node --test tests/integration/playmode/playmode-flow.test.js
- mcp__unity-mcp-server__test_run filter=TestExecutionHandlerTests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Play Mode中のテスト実行を防止する保護機能を追加

* **改善**
  * エディター状態の確認とメッセージング処理を強化
  * ポーリングとエラーハンドリングを改善

* **テスト**
  * Play Mode検出テストを追加
  * エンドツーエンドテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->