### PR TITLE
fix: auto-save dirty scenes before running tests

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/Tests/Editor/Handlers/TestExecutionHandlerTests.cs
+++ b/UnityMCPServer/Packages/unity-mcp-server/Tests/Editor/Handlers/TestExecutionHandlerTests.cs
@@ -50,6 +50,57 @@ namespace UnityMCPServer.Tests
         }
 
         [Test]
+        public void RunTests_ShouldAutoSaveScenesWhenEnabled()
+        {
+            try
+            {
+                TestExecutionHandler.DirtySceneDetector = () => true;
+                TestExecutionHandler.AutoSaveDirtyScenesExecutor = () => (true, null);
+
+                var parameters = new JObject
+                {
+                    ["autoSaveScenes"] = true,
+                    ["testMode"] = "InvalidMode"
+                };
+
+                var result = TestExecutionHandler.RunTests(parameters) as dynamic;
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.error);
+                StringAssert.Contains("Invalid testMode", (string)result.error);
+            }
+            finally
+            {
+                TestExecutionHandler.ResetForTesting();
+            }
+        }
+
+        [Test]
+        public void RunTests_ShouldSurfaceAutoSaveFailures()
+        {
+            try
+            {
+                TestExecutionHandler.DirtySceneDetector = () => true;
+                TestExecutionHandler.AutoSaveDirtyScenesExecutor = () => (false, "Simulated failure");
+
+                var parameters = new JObject
+                {
+                    ["autoSaveScenes"] = true
+                };
+
+                var result = TestExecutionHandler.RunTests(parameters) as dynamic;
+
+                Assert.IsNotNull(result);
+                Assert.IsNotNull(result.error);
+                StringAssert.Contains("Simulated failure", (string)result.error);
+            }
+            finally
+            {
+                TestExecutionHandler.ResetForTesting();
+            }
+        }
+
+        [Test]
         public void RunTests_ShouldFailDuringPlayMode()
         {
             try


### PR DESCRIPTION
## Summary
- add optional auto-saving of dirty scenes before invoking Unity Test Runner
- expose autoSaveScenes flag and surface failures when Unity cannot save a scene
- expand editor tests to cover auto-save success/failure flows

## Testing
- pnpm --filter mcp-server run test:ci (via pre-push hook)
- Unity MCP manual: playmode_play/stop + mcp__scene_save + mcp__test_run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * テスト実行時に未保存シーンの自動保存機能を追加。新しいオプションパラメータにより、テスト開始前にダーティシーンを自動で保存できるようになり、テストワークフローが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->