### PR TITLE
Fix profiler auto-stop handling and clean test logs

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/Editor/Core/UnityMCPServer.cs
+++ b/UnityMCPServer/Packages/unity-mcp-server/Editor/Core/UnityMCPServer.cs
@@ -520,8 +520,6 @@ namespace UnityMCPServer.Core
 
                 var warnings = PlayModeChangeWarningHelper.GetWarnings(command.Type, command.Parameters);
 
-                Debug.LogError($"[UNITY MCP TEST] ProcessCommand received: {command.Type}");
-
                 // Handle command based on type
                 switch (command.Type?.ToLower())
                 {


### PR DESCRIPTION
## Summary
- merge latest develop
- handle profiler auto-stop returning last result instead of error
- remove leftover test logs

## Testing
- git push triggered pre-push test suite (all passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * プロファイラーのセッション停止処理を改善し、以前のセッション結果をより適切に処理するようになりました。
  * 自動停止イベントの追跡機能を追加して、セッション管理の信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->