### PR TITLE
fix: align unity package version

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/package.json
+++ b/UnityMCPServer/Packages/unity-mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.akiojin.unity-mcp-server",
   "displayName": "Unity MCP Server",
-  "version": "2.41.0",
+  "version": "2.41.1",
   "unity": "6000.0",
   "description": "Unity MCP Server bridge and tooling for AI-assisted development (screenshots, video capture, scene analysis, input automation).",
   "keywords": [


### PR DESCRIPTION
- bump Unity package version to 2.41.1 (v2.41.1 tag had 2.41.0)\n- no code changes; ensures next release publishes correct version to OpenUPM