### PR TITLE
chore: add .unity/capture/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ build/
 CLAUDE.local.md
 
 .unity/cache/
+.unity/capture/
 .unity/captures/
 .unity/guid-db/
 .unity/tools/


### PR DESCRIPTION
## Summary
- レガシーの `.unity/capture/` ディレクトリを .gitignore に追加
- 後方互換性のため、旧ディレクトリ名も Git 管理外に設定

## Changes
- **.gitignore**: `.unity/capture/` を追加（`.unity/captures/` と併記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)