### PR TITLE
fix(unity): add missing McpLogger.cs.meta file

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/Editor/Logging/McpLogger.cs.meta
+++ b/UnityMCPServer/Packages/unity-mcp-server/Editor/Logging/McpLogger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5dea696b888370c4a81ee6dfe359eabb


### PR DESCRIPTION
## Summary
- Add missing McpLogger.cs.meta file that was not included in v2.41.6
- This fixes CS0103 compilation errors when installing from OpenUPM

## Root Cause
v2.41.6 included McpLogger.cs but not its corresponding .meta file. Unity requires .meta files for all assets to properly recognize them.

## Test plan
- [x] All 80 tests pass
- [ ] Verify Unity can compile after installing v2.41.7 from OpenUPM

🤖 Generated with [Claude Code](https://claude.com/claude-code)