### PR TITLE
docs: align test specs with current tool names

### DIFF
--- a/tests/test-mcp-animator-tools.md
+++ b/tests/test-mcp-animator-tools.md
@@ -7,10 +7,9 @@
 - Animator 対象が無い場合は全項目を `skip（Animator 無し）` として継続（カテゴリ完走）。
 - Play 依存の項目は条件未満なら `skip（Playでない）` として継続。
 
-
 前提・共通ルール:
 - 禁止: UnityMCP 以外のコマンド・独自スクリプトで操作しない。
-- 使用ツール: `UnityMCP__get_animator_state`, `UnityMCP__get_animator_runtime_info`。
+- 使用ツール: `analysis_animator_state_get`, `analysis_animator_runtime_info_get`。
 
 前提:
 - シーン内に Animator コンポーネントを持つ対象が存在しない場合は `skip`。
@@ -19,17 +18,17 @@
 - 再生状態やパラメータ変更は終了時に元へ戻す。Play 中に限る項目は停止で静止へ戻す。
 
 チェックリスト（Markdown）
-- [ ] A10-01: get_animator_state（対象名を指定、states/parameters）
-- [ ] A10-02: get_animator_runtime_info（IK/root motion 等）
+- [ ] A10-01: analysis_animator_state_get（対象名を指定、states/parameters）
+- [ ] A10-02: analysis_animator_runtime_info_get（IK/root motion 等）
 - [ ] A10-E01: 存在しない対象名で fail
 - [ ] A10-E02: Play でない状態で runtime_info 要求 → skip or fail（仕様準拠）
 
 ## 正常系
 
-- A10-01: `UnityMCP__get_animator_state`（`includeParameters=true`, `includeStates=true`）→ 情報取得
-- A10-02: （Play中）`UnityMCP__get_animator_runtime_info` → 情報取得
+- A10-01: `analysis_animator_state_get`（`includeParameters=true`, `includeStates=true`）→ 情報取得
+- A10-02: （Play中）`analysis_animator_runtime_info_get` → 情報取得
 
 ## 異常系
 
-- A10-E01: `get_animator_state`（存在しない対象）→ `fail`
-- A10-E02: `get_animator_runtime_info`（非Play）→ `fail` または適切応答
+- A10-E01: `analysis_animator_state_get`（存在しない対象）→ `fail`
+- A10-E02: `analysis_animator_runtime_info_get`（非Play）→ `fail` または適切応答

--- a/tests/test-mcp-assets-tools.md
+++ b/tests/test-mcp-assets-tools.md
@@ -6,17 +6,17 @@
 - 取得/検索系は非破壊に。検証で作成した一時アセットはテスト終了時に削除。
 
 チェックリスト（Markdown）
-- [ ] U90-01: package_manager（list, includeBuiltIn=false）
-- [ ] U90-02: manage_asset_database（find_assets, t:Texture2D）
-- [ ] U90-03: manage_asset_import_settings（action=get）
+- [ ] U90-01: package_manage（list, includeBuiltIn=false）
+- [ ] U90-02: asset_database_manage（find_assets, t:Texture2D）
+- [ ] U90-03: asset_import_settings_manage（action=get）
 - [ ] U90-E01: 無効 filter で fail
 - [ ] U90-E02: 存在しない assetPath で fail
 
 ## 正常系
 
-- U90-01: `package_manager`（`action=list`, `includeBuiltIn=false`）→ 一覧取得
-- U90-02: `manage_asset_database`（`action=find_assets`, `filter=t:Texture2D`）→ 検索
-- U90-03: `manage_asset_import_settings`（`action=get`）→ 1件の設定取得
+- U90-01: `package_manage`（`action=list`, `includeBuiltIn=false`）→ 一覧取得
+- U90-02: `asset_database_manage`（`action=find_assets`, `filter=t:Texture2D`）→ 検索
+- U90-03: `asset_import_settings_manage`（`action=get`）→ 1件の設定取得
 
 ## 異常系
 

--- a/tests/test-mcp-capture-tools.md
+++ b/tests/test-mcp-capture-tools.md
@@ -6,16 +6,16 @@
 - 生成したスクリーンショット/動画はテスト成果物として記録し、必要に応じてクリーンアップポリシーに従って削除可能。
 
 チェックリスト（Markdown）
-- [ ] U70-01: capture_screenshot（game, includeUI=true）
-- [ ] U70-02: analyze_screenshot（analysisType=basic）
+- [ ] U70-01: screenshot_capture（game, includeUI=true）
+- [ ] U70-02: screenshot_analyze（analysisType=basic）
 - [ ] U70-03: capture_video_for（durationSec=2）
 - [ ] U70-E01: 不正 captureMode で fail
 - [ ] U70-E02: Recorder 欠如で fail
 
 ## 正常系
 
-- U70-01: `capture_screenshot`（`captureMode=game`, `includeUI=true`）→ 画像作成
-- U70-02: `analyze_screenshot`（`analysisType=basic`）→ 解析
+- U70-01: `screenshot_capture`（`captureMode=game`, `includeUI=true`）→ 画像作成
+- U70-02: `screenshot_analyze`（`analysisType=basic`）→ 解析
 - U70-03: `capture_video_for`（`durationSec=2`）→ 動画作成
 
 ## 異常系

--- a/tests/test-mcp-cleanup-tools.md
+++ b/tests/test-mcp-cleanup-tools.md
@@ -11,14 +11,14 @@
 
 ## 正常系
 
-- U170-01: `delete_gameobject`（`/LLMTEST_Cube`, `/LLMTEST_Cube_Instance`）→ 削除
-- U170-02: `manage_asset_database`（`action=delete` で `Assets/LLMTEST_*` を順次）→ 削除
+- U170-01: `gameobject_delete`（`/LLMTEST_Cube`, `/LLMTEST_Cube_Instance`）→ 削除
+- U170-02: `asset_database_manage`（`action=delete` で `Assets/LLMTEST_*` を順次）→ 削除
 
 ## 異常系
 
 - U170-E01: 不在対象の再削除 → `skip` または `fail`
 
 チェックリスト（Markdown）
-- [ ] U170-01: delete_gameobject（/LLMTEST_Cube, /LLMTEST_Cube_Instance）
-- [ ] U170-02: manage_asset_database（delete, Assets/LLMTEST_*）
+- [ ] U170-01: gameobject_delete（/LLMTEST_Cube, /LLMTEST_Cube_Instance）
+- [ ] U170-02: asset_database_manage（delete, Assets/LLMTEST_*）
 - [ ] U170-E01: 不在対象の再削除は skip/fail として扱う

--- a/tests/test-mcp-common-tools.md
+++ b/tests/test-mcp-common-tools.md
@@ -7,19 +7,19 @@
 - Node 側は全コマンドに `workspaceRoot` を付与
 
 チェックリスト（Markdown）
-- [ ] U00-01: get_editor_state（isPlaying=false）
-- [ ] U00-02: get_project_settings（player/quality/graphics）
-- [ ] U00-03: get_command_stats（集計）
-- [ ] U00-E01: wait_for_editor_state（isPlaying=true, timeoutMs=1）で TIMEOUT（fail）
-- [ ] U00-E02: get_project_settings（未知フラグ）でバリデーション fail
+- [ ] U00-01: playmode_get_state（isPlaying=false）
+- [ ] U00-02: settings_get（player/quality/graphics）
+- [ ] U00-03: system_get_command_stats（集計）
+- [ ] U00-E01: playmode_wait_for_state（isPlaying=true, timeoutMs=1）で TIMEOUT（fail）
+- [ ] U00-E02: settings_get（未知フラグ）でバリデーション fail
 
 ## 正常系
 
-- U00-01: `get_editor_state` → `isPlaying=false`
-- U00-02: `get_project_settings`（player/quality/graphics）→ 取得成功
-- U00-03: `get_command_stats` → 集計取得
+- U00-01: `playmode_get_state` → `isPlaying=false`
+- U00-02: `settings_get`（player/quality/graphics）→ 取得成功
+- U00-03: `system_get_command_stats` → 集計取得
 
 ## 異常系
 
-- U00-E01: `wait_for_editor_state`（`isPlaying=true`, `timeoutMs=1`）→ タイムアウト
-- U00-E02: `get_project_settings` に未知フラグ → バリデーションエラー
+- U00-E01: `playmode_wait_for_state`（`isPlaying=true`, `timeoutMs=1`）→ タイムアウト
+- U00-E02: `settings_get` に未知フラグ → バリデーションエラー

--- a/tests/test-mcp-compilation-refresh-tools.md
+++ b/tests/test-mcp-compilation-refresh-tools.md
@@ -6,14 +6,14 @@
 - リフレッシュ/コンパイルは非破壊だが、他カテゴリと干渉しないタイミングで実施し副作用が残らないようにする。
 
 チェックリスト（Markdown）
-- [ ] U160-01: refresh_assets（完了）
-- [ ] U160-02: get_compilation_state（includeMessages=true, エラー0）
+- [ ] U160-01: system_refresh_assets（完了）
+- [ ] U160-02: compilation_get_state（includeMessages=true, エラー0）
 - [ ] U160-E01: 無効 maxMessages（負数）で fail
 
 ## 正常系
 
-- U160-01: `refresh_assets` → 完了
-- U160-02: `get_compilation_state`（`includeMessages=true`）→ `isCompiling=false`・エラー0（なければ `fail`）
+- U160-01: `system_refresh_assets` → 完了
+- U160-02: `compilation_get_state`（`includeMessages=true`）→ `isCompiling=false`・エラー0（なければ `fail`）
 
 ## 異常系
 

--- a/tests/test-mcp-component-tools.md
+++ b/tests/test-mcp-component-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__list_components`/`UnityMCP__get_component_values` の前後比較（追加/削除/値変更）。
-- 構造検証: `UnityMCP__find_by_component` の一致件数で確認。
-- 参照検証: 依存エラーなどはコンソールログ確認や `get_object_references` 併用。
+- 差分検証: `component_list`/`analysis_component_values_get` の前後比較（追加/削除/値変更）。
+- 構造検証: `analysis_component_find` の一致件数で確認。
+- 参照検証: 依存エラーなどはコンソールログ確認や `analysis_object_references_get` 併用。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
@@ -20,22 +20,22 @@
 前提: 対象 `/LLMTEST_Cube`（未存在なら先に作成）
 
 チェックリスト（Markdown）
-- [ ] U30-01: add_component（Rigidbody）
-- [ ] U30-02: get_component_values（Rigidbody）
-- [ ] U30-03: modify_component（useGravity=false 等）
+- [ ] U30-01: component_add（Rigidbody）
+- [ ] U30-02: analysis_component_values_get（Rigidbody）
+- [ ] U30-03: component_modify（useGravity=false 等）
 - [ ] U30-04: component_field_set（SerializeField 更新）
-- [ ] U30-05: list_components（Rigidbody を含む）
+- [ ] U30-05: component_list（Rigidbody を含む）
 - [ ] U30-E01: 未知 componentType で fail
 - [ ] U30-E02: 不正プロパティ/型不一致で fail
 - [ ] U30-E03: 対象なしで fail
 
 ## 正常系
 
-- U30-01: `add_component`（`Rigidbody`）→ 成功
-- U30-02: `get_component_values`（`Rigidbody`）→ 値取得
-- U30-03: `modify_component`（`useGravity=false` 等）→ 反映
+- U30-01: `component_add`（`Rigidbody`）→ 成功
+- U30-02: `analysis_component_values_get`（`Rigidbody`）→ 値取得
+- U30-03: `component_modify`（`useGravity=false` 等）→ 反映
 - U30-04: `component_field_set`（SerializeField 値更新）→ 反映
-- U30-05: `list_components` → 追加済みが列挙
+- U30-05: `component_list` → 追加済みが列挙
 
 ## 異常系
 

--- a/tests/test-mcp-console-tools.md
+++ b/tests/test-mcp-console-tools.md
@@ -8,7 +8,7 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__read_console` 前後でログ件数/最新時刻/フィルタ結果を比較。
+- 差分検証: `console_read` 前後でログ件数/最新時刻/フィルタ結果を比較。
 - 構造検証: ログ種別（Error/Warning/Info）やフィルタ適用の有無を確認。
 - 参照検証: 期待したエラーメッセージID/キーワードの出現有無を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
@@ -17,14 +17,14 @@
 - クリア実行後は必要に応じてログを再度生成するなど、他テストへの影響が出ないように順序・分離を保つ。
 
 チェックリスト（Markdown）
-- [ ] U80-01: read_console（count=50）
-- [ ] U80-02: clear_console（preserveErrors/Warnings=true）
+- [ ] U80-01: console_read（count=50）
+- [ ] U80-02: console_clear（preserveErrors/Warnings=true）
 - [ ] U80-E01: 不正 logTypes 値で fail
 
 ## 正常系
 
-- U80-01: `read_console`（`count=50`）→ 直近ログ取得
-- U80-02: `clear_console`（`preserveErrors=true`, `preserveWarnings=true`）→ エラー/警告保持
+- U80-01: `console_read`（`count=50`）→ 直近ログ取得
+- U80-02: `console_clear`（`preserveErrors=true`, `preserveWarnings=true`）→ エラー/警告保持
 
 ## 異常系
 

--- a/tests/test-mcp-gameobject-tools.md
+++ b/tests/test-mcp-gameobject-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__analysis_gameobject_details_get` や `UnityMCP__gameobject_get_hierarchy` の前後比較（存在/親子/Transform/タグ/レイヤ）。
-- 構造検証: `UnityMCP__find_gameobject` の一致件数を確認。
-- 参照検証: 参照/依存関係は `UnityMCP__get_object_references` で件数期待を確認。
+- 差分検証: `analysis_gameobject_details_get` や `gameobject_get_hierarchy` の前後比較（存在/親子/Transform/タグ/レイヤ）。
+- 構造検証: `gameobject_find` の一致件数を確認。
+- 参照検証: 参照/依存関係は `analysis_object_references_get` で件数期待を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:

--- a/tests/test-mcp-input-simulation-tools.md
+++ b/tests/test-mcp-input-simulation-tools.md
@@ -8,7 +8,7 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__get_ui_element_state`/ゲーム状態のスクリーンショット（任意）で操作前後の状態差を確認。
+- 差分検証: `ui_get_element_state`/ゲーム状態のスクリーンショット（任意）で操作前後の状態差を確認。
 - 構造検証: 対象要素の interactable/selected 変化で確認。
 - 参照検証: 期待されたログ/イベント（Console/Animator 等）が出力されるか補助確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。

--- a/tests/test-mcp-input-tools.md
+++ b/tests/test-mcp-input-tools.md
@@ -8,8 +8,8 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__get_input_actions_state` で前後比較（actions/maps/bindings の増減）。
-- 構造検証: `UnityMCP__find_ui_elements` 等と併用し、UI の反応/操作可能の変化を確認（必要時）。
+- 差分検証: `input_actions_state_get` で前後比較（actions/maps/bindings の増減）。
+- 構造検証: `find_ui_elements` 等と併用し、UI の反応/操作可能の変化を確認（必要時）。
 - 参照検証: control schemes や devices の有効性/割当変化を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
@@ -17,13 +17,13 @@
 - 追加したアクションマップ/アクション/バインディング/スキームは全てテスト終了時に削除し、既存状態に影響を残さない。
 
 チェックリスト（Markdown）
-- [ ] U60-01: get_input_actions_state（存在確認）
+- [ ] U60-01: input_actions_state_get（存在確認）
 - [ ] U60-02: input_action_map_create（LLMTEST_Map）
-- [ ] U60-03: add_input_action（Jump, Button）
-- [ ] U60-04: add_input_binding（<Keyboard>/space）
+- [ ] U60-03: input_action_add（Jump, Button）
+- [ ] U60-04: input_binding_add（<Keyboard>/space）
 - [ ] U60-05: input_binding_composite_create（2D Vector: WASD）
-- [ ] U60-06: manage_control_schemes（Keyboard&Mouse）
-- [ ] U60-07: analyze_input_actions_asset（統計）
+- [ ] U60-06: input_control_schemes_manage（Keyboard&Mouse）
+- [ ] U60-07: input_actions_asset_analyze（統計）
 - [ ] U60-08: remove 系で片付け
 - [ ] U60-E01: 重複バインディングで fail or notes
 - [ ] U60-E02: 不正デバイス/パスで fail
@@ -31,13 +31,13 @@
 
 ## 正常系（アセットが存在する場合）
 
-- U60-01: `get_input_actions_state` → 状態取得
+- U60-01: `input_actions_state_get` → 状態取得
 - U60-02: `input_action_map_create`（`LLMTEST_Map`）→ 作成
-- U60-03: `add_input_action`（`Jump`, Button）→ 追加
-- U60-04: `add_input_binding`（`<Keyboard>/space`）→ 追加
+- U60-03: `input_action_add`（`Jump`, Button）→ 追加
+- U60-04: `input_binding_add`（`<Keyboard>/space`）→ 追加
 - U60-05: `input_binding_composite_create`（2D Vector: WASD）→ 追加
-- U60-06: `manage_control_schemes`（`Keyboard&Mouse`）→ 追加/確認
-- U60-07: `analyze_input_actions_asset` → 統計
+- U60-06: `input_control_schemes_manage`（`Keyboard&Mouse`）→ 追加/確認
+- U60-07: `input_actions_asset_analyze` → 統計
 - U60-08: 片付け（remove 系）→ 正常削除
 
 ## 異常系

--- a/tests/test-mcp-layers-tags-tools.md
+++ b/tests/test-mcp-layers-tags-tools.md
@@ -6,29 +6,29 @@
 - 追加したレイヤー/タグはテスト終了時に削除（元の設定に戻す）。
 
 チェックリスト（Markdown）
-- [ ] L10-01: manage_layers（action=get）→ 一覧取得
-- [ ] L10-02: manage_layers（action=add, layerName=LLMTEST_Layer）→ 追加
-- [ ] L10-03: manage_layers（action=get_by_name, layerName=LLMTEST_Layer）→ 存在確認
-- [ ] L10-04: manage_layers（action=remove, layerName=LLMTEST_Layer）→ 削除
+- [ ] L10-01: editor_layers_manage（action=get）→ 一覧取得
+- [ ] L10-02: editor_layers_manage（action=add, layerName=LLMTEST_Layer）→ 追加
+- [ ] L10-03: editor_layers_manage（action=get_by_name, layerName=LLMTEST_Layer）→ 存在確認
+- [ ] L10-04: editor_layers_manage（action=remove, layerName=LLMTEST_Layer）→ 削除
 - [ ] L10-E01: 予約名/不正名で add → fail（検証）
 - [ ] L10-E02: 不存在 remove → fail もしくは適切な応答
-- [ ] T10-01: manage_tags（action=get）→ 一覧取得
-- [ ] T10-02: manage_tags（action=add, tagName=LLMTEST_Tag）→ 追加
-- [ ] T10-03: manage_tags（action=remove, tagName=LLMTEST_Tag）→ 削除
+- [ ] T10-01: editor_tags_manage（action=get）→ 一覧取得
+- [ ] T10-02: editor_tags_manage（action=add, tagName=LLMTEST_Tag）→ 追加
+- [ ] T10-03: editor_tags_manage（action=remove, tagName=LLMTEST_Tag）→ 削除
 - [ ] T10-E01: 不正名 add/remove → fail
 
 ## 正常系
 
-- L10-01: `manage_layers`（`action=get`）→ 一覧
-- L10-02: `manage_layers`（`action=add`, `layerName=LLMTEST_Layer`）→ 追加
-- L10-03: `manage_layers`（`action=get_by_name`）→ 存在
-- L10-04: `manage_layers`（`action=remove`）→ 削除
-- T10-01: `manage_tags`（`action=get`）→ 一覧
-- T10-02: `manage_tags`（`action=add`, `tagName=LLMTEST_Tag`）→ 追加
-- T10-03: `manage_tags`（`action=remove`, `tagName=LLMTEST_Tag`）→ 削除
+- L10-01: `editor_layers_manage`（`action=get`）→ 一覧
+- L10-02: `editor_layers_manage`（`action=add`, `layerName=LLMTEST_Layer`）→ 追加
+- L10-03: `editor_layers_manage`（`action=get_by_name`）→ 存在
+- L10-04: `editor_layers_manage`（`action=remove`）→ 削除
+- T10-01: `editor_tags_manage`（`action=get`）→ 一覧
+- T10-02: `editor_tags_manage`（`action=add`, `tagName=LLMTEST_Tag`）→ 追加
+- T10-03: `editor_tags_manage`（`action=remove`, `tagName=LLMTEST_Tag`）→ 削除
 
 ## 異常系
 
-- L10-E01: `manage_layers`（`action=add`, 予約名/不正形式）→ `fail`
-- L10-E02: `manage_layers`（`action=remove`, 存在しない）→ `fail` または適切応答
-- T10-E01: `manage_tags`（`action=add/remove`, 不正名）→ `fail`
+- L10-E01: `editor_layers_manage`（`action=add`, 予約名/不正形式）→ `fail`
+- L10-E02: `editor_layers_manage`（`action=remove`, 存在しない）→ `fail` または適切応答
+- T10-E01: `editor_tags_manage`（`action=add/remove`, 不正名）→ `fail`

--- a/tests/test-mcp-material-tools.md
+++ b/tests/test-mcp-material-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__asset_material_modify` 適用の前後でプロパティ値を比較（事前は `UnityMCP__asset_material_create`/既存読取）。
+- 差分検証: `asset_material_modify` 適用の前後でプロパティ値を比較（事前は `asset_material_create`/既存読取）。
 - 構造検証: マテリアルの shader/keywords 変化を確認。
-- 参照検証: マテリアル参照箇所の増減は `get_object_references` で補助。
+- 参照検証: マテリアル参照箇所の増減は `analysis_object_references_get` で補助。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:

--- a/tests/test-mcp-play-pause-tools.md
+++ b/tests/test-mcp-play-pause-tools.md
@@ -8,25 +8,25 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__get_editor_state` の `isPlaying` 等の前後比較。
+- 差分検証: `playmode_get_state` の `isPlaying` 等の前後比較。
 - 構造検証: 再生/停止中のログや Animator/Update の動作で補助確認。
-- 参照検証: `UnityMCP__read_console` によるステート遷移ログの有無を確認。
+- 参照検証: `console_read` によるステート遷移ログの有無を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
-- テスト終了時は必ず `stop_game` で `isPlaying=false` の静止状態に戻す。
+- テスト終了時は必ず `playmode_stop` で `isPlaying=false` の静止状態に戻す。
 
 チェックリスト（Markdown）
-- [ ] U120-01: play_game → wait_for_editor_state(isPlaying=true)
-- [ ] U120-02: pause_game → get_editor_state
-- [ ] U120-03: stop_game → wait_for_editor_state(isPlaying=false)
+- [ ] U120-01: playmode_play → playmode_wait_for_state(isPlaying=true)
+- [ ] U120-02: playmode_pause → playmode_get_state
+- [ ] U120-03: playmode_stop → playmode_wait_for_state(isPlaying=false)
 - [ ] U120-E01: 短すぎる timeoutMs で TIMEOUT（fail）
 
 ## 正常系
 
-- U120-01: `play_game` → `wait_for_editor_state(isPlaying=true)`
-- U120-02: `pause_game` → `get_editor_state`
-- U120-03: `stop_game` → `wait_for_editor_state(isPlaying=false)`
+- U120-01: `playmode_play` → `playmode_wait_for_state(isPlaying=true)`
+- U120-02: `playmode_pause` → `playmode_get_state`
+- U120-03: `playmode_stop` → `playmode_wait_for_state(isPlaying=false)`
 
 ## 異常系
 

--- a/tests/test-mcp-prefab-tools.md
+++ b/tests/test-mcp-prefab-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__asset_prefab_open` 後に `UnityMCP__list_components`/`UnityMCP__get_gameobject_details` の前後比較。
+- 差分検証: `asset_prefab_open` 後に `component_list`/`analysis_gameobject_details_get` の前後比較。
 - 構造検証: Prefab インスタンス化後のヒエラルキー差分で確認。
-- 参照検証: 参照/依存の増減を `get_object_references` で確認。
+- 参照検証: 参照/依存の増減を `analysis_object_references_get` で確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
@@ -21,7 +21,7 @@
 
 チェックリスト（Markdown）
 - [ ] U50-01: asset_prefab_create（/LLMTEST_Cube → Prefab 作成）
-- [ ] U50-02: asset_prefab_open → add_component(BoxCollider) → asset_prefab_save → asset_prefab_exit_mode
+- [ ] U50-02: asset_prefab_open → component_add(BoxCollider) → asset_prefab_save → asset_prefab_exit_mode
 - [ ] U50-03: asset_prefab_instantiate（LLMTEST_Cube_Instance）
 - [ ] U50-04: asset_prefab_modify（applyToInstances=true で反映）
 - [ ] U50-E01: Assets 外パス保存で fail
@@ -31,7 +31,7 @@
 ## 正常系
 
 - U50-01: `asset_prefab_create` → 成功
-- U50-02: `asset_prefab_open` → `add_component(BoxCollider)` → `asset_prefab_save` → `asset_prefab_exit_mode`
+- U50-02: `asset_prefab_open` → `component_add(BoxCollider)` → `asset_prefab_save` → `asset_prefab_exit_mode`
 - U50-03: `asset_prefab_instantiate`（`LLMTEST_Cube_Instance`）→ 生成
 - U50-04: `asset_prefab_modify`（`applyToInstances=true`）→ 反映
 

--- a/tests/test-mcp-project-settings-tools.md
+++ b/tests/test-mcp-project-settings-tools.md
@@ -8,7 +8,7 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__get_project_settings` の前後比較（適用前/適用後）。
+- 差分検証: `settings_get` の前後比較（適用前/適用後）。
 - 構造検証: 変更対象カテゴリ（player/graphics/quality 等）のキー値が期待どおり変化しているか確認。
 - 参照検証: Quality/Graphics の変更が GameView などに反映されるかは必要に応じて補助。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
@@ -17,16 +17,16 @@
 - 変更前の設定値（例: `vSyncCount`）を必ず保存し、テスト終了時に元の値へ復元する。
 
 チェックリスト（Markdown）
-- [ ] U110-01: get_project_settings（quality.vSyncCount 確認）
-- [ ] U110-02: update_project_settings（confirmChanges=true で一時変更）
+- [ ] U110-01: settings_get（quality.vSyncCount 確認）
+- [ ] U110-02: settings_update（confirmChanges=true で一時変更）
 - [ ] U110-03: 変更確認→復元
 - [ ] U110-E01: confirmChanges=false で fail
 - [ ] U110-E02: 不正値（例: vSyncCount=-1）で fail
 
 ## 正常系
 
-- U110-01: `get_project_settings`（quality）→ `vSyncCount` を取得
-- U110-02: `update_project_settings`（`confirmChanges=true`）で一時変更（0↔1）
+- U110-01: `settings_get`（quality）→ `vSyncCount` を取得
+- U110-02: `settings_update`（`confirmChanges=true`）で一時変更（0↔1）
 - U110-03: 変更確認後に復元
 
 ## 異常系

--- a/tests/test-mcp-references-selection-tools.md
+++ b/tests/test-mcp-references-selection-tools.md
@@ -8,15 +8,15 @@
 前提: 対象 `/LLMTEST_Cube`
 
 チェックリスト（Markdown）
-- [ ] U100-01: get_object_references（参照情報）
-- [ ] U100-02: manage_selection（set→get）
+- [ ] U100-01: analysis_object_references_get（参照情報）
+- [ ] U100-02: editor_selection_manage（set→get）
 - [ ] U100-E01: 存在しない対象で fail
 - [ ] U100-E02: 不正選択パスで fail
 
 ## 正常系
 
-- U100-01: `get_object_references` → 参照情報が返る
-- U100-02: `manage_selection`（set → get）→ 選択が反映
+- U100-01: `analysis_object_references_get` → 参照情報が返る
+- U100-02: `editor_selection_manage`（set → get）→ 選択が反映
 
 ## 異常系
 

--- a/tests/test-mcp-registry-tools.md
+++ b/tests/test-mcp-registry-tools.md
@@ -6,15 +6,15 @@
 - 既存のレジストリ設定には影響を与えない。`recommend`/`list` 等の非破壊操作に限定。
 
 チェックリスト（Markdown）
-- [ ] R10-01: registry_config（action=recommend, registry=OpenUPM）→ 推奨スコープ取得
-- [ ] R10-02: registry_config（action=get）→ 現在の登録状況取得
+- [ ] R10-01: package_registry_config（action=recommend, registry=OpenUPM）→ 推奨スコープ取得
+- [ ] R10-02: package_registry_config（action=get）→ 現在の登録状況取得
 - [ ] R10-E01: 不正 registry 名 → fail
 
 ## 正常系
 
-- R10-01: `UnityMCP__registry_config`（`action=recommend`, `registry=OpenUPM`）→ 推奨スコープが得られる
-- R10-02: `UnityMCP__registry_config`（`action=get`）→ 現在のスコープ一覧
+- R10-01: `package_registry_config`（`action=recommend`, `registry=OpenUPM`）→ 推奨スコープが得られる
+- R10-02: `package_registry_config`（`action=get`）→ 現在のスコープ一覧
 
 ## 異常系
 
-- R10-E01: `registry_config`（未知の `registry`）→ `fail`
+- R10-E01: `package_registry_config`（未知の `registry`）→ `fail`

--- a/tests/test-mcp-scene-analysis-tools.md
+++ b/tests/test-mcp-scene-analysis-tools.md
@@ -8,23 +8,23 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__analyze_scene_contents` の前後比較（object counts/memory 推定等）。
-- 構造検証: `UnityMCP__get_hierarchy` で構成変化を補助確認。
-- 参照検証: 変化対象に対する参照の有無を `get_object_references` で補助。
+- 差分検証: `analysis_scene_contents_analyze` の前後比較（object counts/memory 推定等）。
+- 構造検証: `gameobject_get_hierarchy` で構成変化を補助確認。
+- 参照検証: 変化対象に対する参照の有無を `analysis_object_references_get` で補助。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
 - 解析は非破壊。必要に応じて一時オブジェクトを生成した場合は削除。
 
 チェックリスト（Markdown）
-- [ ] SA10-01: analyze_scene_contents（includeInactive=true, groupByType=true）
-- [ ] SA10-02: get_hierarchy（nameOnly=true, maxObjects=100）
+- [ ] SA10-01: analysis_scene_contents_analyze（includeInactive=true, groupByType=true）
+- [ ] SA10-02: gameobject_get_hierarchy（nameOnly=true, maxObjects=100）
 - [ ] SA10-E01: パラメータ不正（maxObjects<0 等）で fail
 
 ## 正常系
 
-- SA10-01: `UnityMCP__analyze_scene_contents` → 種別ごとの集計が取得できる
-- SA10-02: `UnityMCP__get_hierarchy`（nameOnly, maxObjects）→ ヒエラルキー取得
+- SA10-01: `analysis_scene_contents_analyze` → 種別ごとの集計が取得できる
+- SA10-02: `gameobject_get_hierarchy`（nameOnly, maxObjects）→ ヒエラルキー取得
 
 ## 異常系
 

--- a/tests/test-mcp-scene-tools.md
+++ b/tests/test-mcp-scene-tools.md
@@ -8,8 +8,8 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__scene_info_get`/`UnityMCP__get_hierarchy` で実行前後のスナップショットを取得し比較（追加/削除/ロード状態）。
-- 構造検証: `UnityMCP__scene_list` の一覧変化で確認。
+- 差分検証: `scene_info_get`/`gameobject_get_hierarchy` で実行前後のスナップショットを取得し比較（追加/削除/ロード状態）。
+- 構造検証: `scene_list` の一覧変化で確認。
 - 参照検証: 必要に応じて対象シーン名の検索・一致件数で確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
@@ -18,10 +18,9 @@
 - 作成や保存が安全側で拒否される場合や前提未充足の項目は「skip（理由）」で継続する。
 - 復元は必須。差分が残らない状態に戻せば restored:true とする。
 
-
 前提・共通ルール:
 - 禁止: UnityMCP 以外のコマンド・独自スクリプトで操作しない。
-- 使用ツール: `UnityMCP__scene_create`, `UnityMCP__scene_info_get`, `UnityMCP__scene_list`, `UnityMCP__scene_save`。
+- 使用ツール: `scene_create`, `scene_info_get`, `scene_list`, `scene_save`。
 
 原状回復（必須）・禁止事項:
 - 作成したシーンはテスト内で保存後、必要に応じて削除または閉じる。既存シーンの変更は行わない。

--- a/tests/test-mcp-script-tools.md
+++ b/tests/test-mcp-script-tools.md
@@ -10,7 +10,7 @@
 
 チェックリスト（Markdown）
 - [ ] S00-00: ラン初期化（事前 .sln チェックは行わない）
- - [ ] S00-X01: LSP 自動ダウンロード/復旧（バイナリ未配置→自動取得、破損→再取得、英語エラー）
+- [ ] S00-X01: LSP 自動ダウンロード/復旧（バイナリ未配置→自動取得、破損→再取得、英語エラー）
 - [ ] S10-01: script_symbols_get で FinalTestClass/TestMethod11/12 確認
 - [ ] S10-02: script_symbol_find で namePath 補助確定
 - [ ] S10-E01: 存在しないファイルで script_symbols_get は fail
@@ -22,22 +22,22 @@
 - [ ] S30-02: 旧名 refs=0 確認
 - [ ] S30-E01: 既存名への衝突で fail
 - [ ] S30-E02: 曖昧 namePath で applied=false
- - [ ] S30-X01: using エイリアス経由の型参照（終端一致時のみ更新）
- - [ ] S30-X02: ネスト型のリネーム（親コンテナ一致のみ）
- - [ ] S30-X03: ジェネリック型/メソッドの識別子更新（型は横断、メンバーは宣言ファイル内）
- - [ ] S30-X04: オーバーロードの一部のみリネーム（他は未変更）
- - [ ] S30-X05: プロパティ/イベントのメンバーリネーム（宣言ファイル内のみ）
+- [ ] S30-X01: using エイリアス経由の型参照（終端一致時のみ更新）
+- [ ] S30-X02: ネスト型のリネーム（親コンテナ一致のみ）
+- [ ] S30-X03: ジェネリック型/メソッドの識別子更新（型は横断、メンバーは宣言ファイル内）
+- [ ] S30-X04: オーバーロードの一部のみリネーム（他は未変更）
+- [ ] S30-X05: プロパティ/イベントのメンバーリネーム（宣言ファイル内のみ）
 - [ ] S40-01: remove_symbol（TestMethod12）→ 欠落確認
 - [ ] S40-E01: failOnReferences=true でブロック
 - [ ] S40-E02: 存在しないシンボルで fail
- - [ ] S40-X01: 部分クラス内の私有メソッド削除（構文維持）
- - [ ] S40-X02: 属性の削除（影響なし）
- - [ ] S40-X03: インターフェース明示実装メソッド削除は拒否（参照あり）
- - [ ] S40-X04: イベントフィールド削除（参照有無で挙動差）
- - [ ] S40-X05: 未使用 enum メンバー削除
+- [ ] S40-X01: 部分クラス内の私有メソッド削除（構文維持）
+- [ ] S40-X02: 属性の削除（影響なし）
+- [ ] S40-X03: インターフェース明示実装メソッド削除は拒否（参照あり）
+- [ ] S40-X04: イベントフィールド削除（参照有無で挙動差）
+- [ ] S40-X05: 未使用 enum メンバー削除
 - [ ] S50-01: refs_find ページング/トリム（truncated, snippetTruncated）
 - [ ] S50-E01: 極端な上限設定での挙動
- - [ ] S50-X01: コメント/文字列の誤検出抑制とスニペット可読性
+- [ ] S50-X01: コメント/文字列の誤検出抑制とスニペット可読性
 - [ ] S60-01: 要約上限（errors<=30, message<=200, 1000文字+Truncated）
 - [ ] S60-02: preview/diff/text/content が 1000 文字以内＋ Truncated フラグ
 - [ ] S60-E01: 要約不能データで fail
@@ -50,12 +50,12 @@
 - [ ] S90-01: 後片付け（元状態へ完全復元）
 
  出力フォーマット要約（Script系の例: Markdown レポート）
- - 追記先: `tests/.reports/.current-run` のパスを必ず参照し、同一レポートへ追記（新規ファイル作成禁止）
- - チェックリスト行（PASS 例）: `- [x] S20-01 置換適用 — pass (250 ms) restored:true`
- - テスト仕様・所感・操作対象の明記（必須）:
-   - Run ヘッダ: `- テスト仕様: tests/test-mcp-script-tools.md`、`- 所感: <短文>`
-   - 本カテゴリ見出し直後: `- テスト仕様: tests/test-mcp-script-tools.md`、任意で `- 操作対象ファイル: Assets/Scripts/GigaTestFile.cs`
-   - 各ケース details: `targetPaths: [Assets/Scripts/GigaTestFile.cs]`（単一でも配列）
+- 追記先: `tests/.reports/.current-run` のパスを必ず参照し、同一レポートへ追記（新規ファイル作成禁止）
+- チェックリスト行（PASS 例）: `- [x] S20-01 置換適用 — pass (250 ms) restored:true`
+- テスト仕様・所感・操作対象の明記（必須）:
+  - Run ヘッダ: `- テスト仕様: tests/test-mcp-script-tools.md`、`- 所感: <短文>`
+  - 本カテゴリ見出し直後: `- テスト仕様: tests/test-mcp-script-tools.md`、任意で `- 操作対象ファイル: Assets/Scripts/GigaTestFile.cs`
+  - 各ケース details: `targetPaths: [Assets/Scripts/GigaTestFile.cs]`（単一でも配列）
   
   サマリはレポート先頭のテーブルで集計（`tests/RESULTS_FORMAT.md` 参照）。
 
@@ -107,9 +107,9 @@ S00) ラン初期化（.sln 事前チェックは行わない）
 
 チェックリスト（順に実施）:
 1. レポート/ポインタ初期化（必須）: `tests/.reports/.current-run` へランファイルのパスを書き出す。
-2. UnityMCP ツール到達性: `UnityMCP__script_symbols_get` など最小呼び出しが応答することを確認（0件でも可）。
+2. UnityMCP ツール到達性: `script_symbols_get` など最小呼び出しが応答することを確認（0件でも可）。
 3. パス制約: 以降の `path`/`relative` は必ず `Assets/` または `Packages/` 起点で指定する。
-4. インデックス状況: `code_index_status` でカバレッジを確認し、低ければ（任意）`UnityMCP__code_index_build` を実行して再確認する。
+4. インデックス状況: `code_index_status` でカバレッジを確認し、低ければ（任意）`code_index_build` を実行して再確認する。
 5. 到達性確認: 最小ファイルに対して `script_symbols_get` が成功することを確認（0件でも可）。
 
 ブロック方針:
@@ -117,7 +117,7 @@ S00) ラン初期化（.sln 事前チェックは行わない）
 
 ## 前提・共通ルール
 
-- 禁止: LSPサーバを直接起動・操作しない。必ず UnityMCP の `script_*` ツールで検証する（例: `UnityMCP__script_symbols_get`, `UnityMCP__script_edit_structured`）。
+- 禁止: LSPサーバを直接起動・操作しない。必ず UnityMCP の `script_*` ツールで検証する（例: `script_symbols_get`, `script_edit_structured`）。
 - パスは必ず `Assets/` または `Packages/` 起点の相対パス
 - `namePath`/`symbolName` は `Outer/Nested/Member` 形式（例: `FinalTestClass/TestMethod12`）を優先
 - 大量診断（CS0234 等）は想定内。適用可否は `applied` で判断し、実ファイルは `script_read` で確認

--- a/tests/test-mcp-ui-tools.md
+++ b/tests/test-mcp-ui-tools.md
@@ -8,8 +8,8 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__get_ui_element_state` で操作前後の状態（interactable/value/visible 等）を比較。
-- 構造検証: `UnityMCP__find_ui_elements` の列挙結果の変化で確認。
+- 差分検証: `ui_get_element_state` で操作前後の状態（interactable/value/visible 等）を比較。
+- 構造検証: `ui_find_elements` の列挙結果の変化で確認。
 - 参照検証: 対象 `elementPath` の一致件数や有効/無効の切り替わりで確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
@@ -18,25 +18,24 @@
 - UI が存在しない場合は全項目を `skip（UI 無し）` で埋めて継続（カテゴリ完走）。
 - 操作系が安全側で拒否される場合は `skip（理由）` とし、復元の要否を確認する。
 
-
 前提・共通ルール:
 - 禁止: UnityMCP 以外のコマンド・独自スクリプトで操作しない。
-- 使用ツール: `UnityMCP__find_ui_elements`, `UnityMCP__get_ui_element_state`, `UnityMCP__click_ui_element`, `UnityMCP__set_ui_element_value`。
+- 使用ツール: `ui_find_elements`, `ui_get_element_state`, `ui_click_element`, `ui_set_element_value`。
 
 原状回復（必須）・禁止事項:
 - 値設定やトグル変更を行った場合は、終了時に元の値に戻す。テスト専用 UI を対象にすることが望ましい。
 
 チェックリスト（Markdown）
-- [ ] U140-01: find_ui_elements（Button 等）
-- [ ] U140-02: get_ui_element_state（interactable 等）
-- [ ] U140-03: click_ui_element / set_ui_element_value（反映確認）
+- [ ] U140-01: ui_find_elements（Button 等）
+- [ ] U140-02: ui_get_element_state（interactable 等）
+- [ ] U140-03: ui_click_element / ui_set_element_value（反映確認）
 - [ ] U140-E01: 不正 elementPath で fail
 
 ## 正常系（UI が存在する場合）
 
-- U140-01: `find_ui_elements`（`Button` 等）→ 列挙
-- U140-02: `get_ui_element_state` → 状態取得
-- U140-03: `click_ui_element` / `set_ui_element_value` → 操作成功
+- U140-01: `ui_find_elements`（`Button` 等）→ 列挙
+- U140-02: `ui_get_element_state` → 状態取得
+- U140-03: `ui_click_element` / `ui_set_element_value` → 操作成功
 
 ## 異常系
 

--- a/tests/test-mcp-windows-tools.md
+++ b/tests/test-mcp-windows-tools.md
@@ -8,8 +8,8 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `UnityMCP__manage_windows(action=get_state)` の前後比較（フォーカス/可視状態/配置）。
-- 構造検証: `UnityMCP__manage_windows(action=get)` の一覧に対象が存在/消失していること。
+- 差分検証: `editor_windows_manage(action=get_state)` の前後比較（フォーカス/可視状態/配置）。
+- 構造検証: `editor_windows_manage(action=get)` の一覧に対象が存在/消失していること。
 - 参照検証: ターゲット windowType の一意/複数性を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
@@ -18,26 +18,25 @@
 - 不在ウィンドウ種や未知ツールは `skip（理由）` として継続する。
 - フォーカス等の操作が安全側で拒否される場合も `skip（理由）` とし、復元方針を明記。
 
-
 前提・共通ルール:
 - 禁止: UnityMCP 以外のコマンド・独自スクリプトで操作しない。
-- 使用ツール: `UnityMCP__manage_windows`, `UnityMCP__manage_tools`。
+- 使用ツール: `editor_windows_manage`, `editor_tools_manage`。
 
 原状回復（必須）・禁止事項:
 - フォーカス操作などの状態変更は、終了時に元のウィンドウ状態へ戻すか影響が出ない構成で実行。
 
 チェックリスト（Markdown）
-- [ ] U150-01: manage_windows（action=get, includeHidden=true）
-- [ ] U150-02: manage_tools（action=get）
-- [ ] U150-E01: manage_windows（focus, 不在 windowType）で fail
-- [ ] U150-E02: manage_tools（activate, 不明 toolName）で fail
+- [ ] U150-01: editor_windows_manage（action=get, includeHidden=true）
+- [ ] U150-02: editor_tools_manage（action=get）
+- [ ] U150-E01: editor_windows_manage（focus, 不在 windowType）で fail
+- [ ] U150-E02: editor_tools_manage（activate, 不明 toolName）で fail
 
 ## 正常系
 
-- U150-01: `manage_windows`（`action=get`, `includeHidden=true`）→ 一覧
-- U150-02: `manage_tools`（`action=get`）→ 一覧
+- U150-01: `editor_windows_manage`（`action=get`, `includeHidden=true`）→ 一覧
+- U150-02: `editor_tools_manage`（`action=get`）→ 一覧
 
 ## 異常系
 
-- U150-E01: `manage_windows` フォーカス（存在しない `windowType`）→ `fail`
-- U150-E02: `manage_tools` activate（不明 `toolName`）→ `fail`
+- U150-E01: `editor_windows_manage` フォーカス（存在しない `windowType`）→ `fail`
+- U150-E02: `editor_tools_manage` activate（不明 `toolName`）→ `fail`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **テスト・チア**
  * テスト ドキュメント全体にわたる機能名の標準化と整理を実施しました。内部的な命名規則の統一により、テストの一貫性と保守性が向上します。

* **リファクタリング**
  * API関数の命名規則を統一し、より一貫性のある呼び出しパターンを実現しました。既存の機能動作に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->