### PR TITLE
fix(lsp): add grace period for LSP process shutdown on timeout recovery

### DIFF
--- a/mcp-server/src/lsp/LspRpcClient.js
+++ b/mcp-server/src/lsp/LspRpcClient.js
@@ -154,9 +154,9 @@ export class LspRpcClient {
       const msg = String((e && e.message) || e);
       const recoverable = /timed out|LSP process exited/i.test(msg);
       if (recoverable && attempt === 1) {
-        // Auto-reinit and retry once
+        // Auto-reinit and retry once with grace period for proper LSP shutdown
         try {
-          await this.mgr.stop(0);
+          await this.mgr.stop(3000);
         } catch {}
         this.proc = null;
         this.initialized = false;


### PR DESCRIPTION
## Summary
- Changed `stop(0)` to `stop(3000)` in `LspRpcClient.js` to allow proper LSP shutdown/exit sequence completion
- The immediate process kill (graceMs=0) could corrupt the MCP transport state during timeout recovery

## Problem
Issue #162 reported that after `script_edit_structured` timed out (60s), subsequent MCP calls failed with "Transport closed" error. Another agent could connect simultaneously, indicating the problem was on the Node side, specifically in LSP process management.

## Root Cause
In `LspRpcClient.js` line 159, when a recoverable error (timeout/process exit) occurred, the code called `this.mgr.stop(0)` which immediately killed the LSP process without allowing the proper shutdown/exit sequence to complete.

## Solution
Changed `stop(0)` to `stop(3000)` to give the LSP process 3 seconds to complete its shutdown sequence before forced termination.

## Test Plan
- [x] Existing unit tests pass
- [x] Manual testing: `script_edit_structured` works correctly with preview mode
- [x] CI pre-push checks pass

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)