### PR TITLE
docs(readme): add npx cache and timeout troubleshooting

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -606,6 +606,28 @@ Codex の MCP サーバー設定は次のファイルに作成してください
 - UnityのTCPが待受しない: プロジェクトを開き直し／ポート6400の占有を解除。
 - Node.jsが接続できない: Unity稼働確認、FW設定、Unity/Nodeのログ確認。
 - C#の型が見つからない: アセットをリフレッシュし、コンパイル完了まで待機。
+- **npx ENOTEMPTY エラー**: `npx @akiojin/unity-mcp-server@latest` 実行時に `ENOTEMPTY: directory not empty, rename ...` エラーが発生する場合は、npx キャッシュをクリアしてください:
+
+  ```bash
+  # 特定のキャッシュをクリア（エラーメッセージに表示されたパスを使用）
+  rm -rf ~/.npm/_npx/<ハッシュ値>
+  # または全 npx キャッシュをクリア
+  rm -rf ~/.npm/_npx
+  ```
+
+  これは npm/npx のキャッシュ破損の問題であり、unity-mcp-server のバグではありません。
+- **Unity Editor未起動時の接続タイムアウト**: MCPサーバーはunity-mcp-serverパッケージがインストールされたUnity Editorが起動している必要があります。Unityが起動していない場合、サーバーは30秒後にタイムアウトします。MCPサーバーを起動する前に、パッケージを含むプロジェクトでUnity Editorを開いていることを確認してください。
+
+### デバッグログ
+
+接続問題をトラブルシューティングするには、詳細ログを有効にしてください:
+
+```bash
+# ログレベルをdebugに設定
+LOG_LEVEL=debug npx @akiojin/unity-mcp-server@latest
+```
+
+利用可能なログレベル: `debug`, `info`（デフォルト）, `warn`
 
 ## リリースプロセス
 

--- a/README.md
+++ b/README.md
@@ -564,6 +564,28 @@ Example:
 - Unity TCP not listening: reopen project; ensure port 6400 is free.
 - Node.js cannot connect: Unity running? firewall? logs in Unity/Node terminals.
 - C# types missing: refresh assets and wait until compilation completes.
+- **npx ENOTEMPTY error**: If you see `ENOTEMPTY: directory not empty, rename ...` when running `npx @akiojin/unity-mcp-server@latest`, clear the npx cache:
+
+  ```bash
+  # Clear specific cache (replace hash with actual path from error)
+  rm -rf ~/.npm/_npx/<hash>
+  # Or clear all npx cache
+  rm -rf ~/.npm/_npx
+  ```
+
+  This is an npm/npx cache corruption issue, not a unity-mcp-server bug.
+- **Connection timeout without Unity Editor**: The MCP server requires Unity Editor to be running with the unity-mcp-server package installed. If Unity is not running, the server will timeout after 30 seconds. Ensure Unity Editor is open with the project containing the package before starting the MCP server.
+
+### Debug Logging
+
+To troubleshoot connection issues, enable verbose logging:
+
+```bash
+# Set log level to debug
+LOG_LEVEL=debug npx @akiojin/unity-mcp-server@latest
+```
+
+Available log levels: `debug`, `info` (default), `warn`
 
 ## Release Process
 


### PR DESCRIPTION
## Summary

- npx ENOTEMPTY エラーの回避策を追加（npx キャッシュ破損問題）
- Unity Editor 未起動時の接続タイムアウトの説明を追加
- デバッグログ機能のドキュメントを追加（`LOG_LEVEL` 環境変数）

## 変更内容

### README.md / README.ja.md

トラブルシューティングセクションに以下を追加:

1. **npx ENOTEMPTY エラー**: npx キャッシュの破損により発生するエラーの回避策
2. **接続タイムアウト**: Unity Editor が起動していない場合のタイムアウト問題の説明
3. **デバッグログ**: `LOG_LEVEL=debug` 環境変数によるデバッグログ有効化の説明

## Test plan

- [x] markdownlint でエラーなし（追加部分）
- [x] README.md / README.ja.md の構文チェック

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)