### PR TITLE
fix: add startup diagnostics and WSL2/Docker troubleshooting guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,9 +22,9 @@ Unity MCP Server は、LLMクライアントからUnity Editorを自動化しま
 ### セットアップ
 Unity: Package Manager → git URL から追加 → `https://github.com/akiojin/unity-mcp-server.git?path=UnityMCPServer/Packages/unity-mcp-server`
 MCPクライアント設定例 (Claude Desktop):
-  - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-  - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-  - 追加例:
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- 追加例:
     ```json
     {
       "mcpServers": {
@@ -616,7 +616,7 @@ Codex の MCP サーバー設定は次のファイルに作成してください
   ```
 
   これは npm/npx のキャッシュ破損の問題であり、unity-mcp-server のバグではありません。
-- **Unity Editor未起動時の接続タイムアウト**: MCPサーバーはunity-mcp-serverパッケージがインストールされたUnity Editorが起動している必要があります。Unityが起動していない場合、サーバーは30秒後にタイムアウトします。MCPサーバーを起動する前に、パッケージを含むプロジェクトでUnity Editorを開いていることを確認してください。
+- **Unity接続失敗**: MCPサーバーはUnity Editorが起動していなくてもクライアント接続を受け付け、動作を開始します。ただし、Unity連携が必要なツール呼び出し（`screenshot_capture`、`gameobject_create`など）は接続エラーになります。サーバーはバックグラウンドで自動的にUnity接続をリトライします。全機能を利用するには、unity-mcp-serverパッケージがインストールされたUnity Editorを起動してください。
 
 ### デバッグログ
 
@@ -628,6 +628,108 @@ LOG_LEVEL=debug npx @akiojin/unity-mcp-server@latest
 ```
 
 利用可能なログレベル: `debug`, `info`（デフォルト）, `warn`
+
+### 起動時の診断情報
+
+サーバーは起動時に診断情報をstderrに出力します:
+
+```
+[unity-mcp-server] Startup config:
+[unity-mcp-server]   Config file: /path/to/.unity/config.json
+[unity-mcp-server]   Unity host: localhost
+[unity-mcp-server]   Unity port: 6400
+[unity-mcp-server]   Workspace root: /path/to/workspace
+[unity-mcp-server] MCP transport connecting...
+[unity-mcp-server] MCP transport connected
+[unity-mcp-server] Unity TCP connecting to localhost:6400...
+[unity-mcp-server] Unity TCP connected successfully
+```
+
+これにより、特にクロスプラットフォーム環境での設定ミスマッチを特定できます。
+
+### WSL2/DockerからWindows上のUnityへの接続
+
+MCPサーバーをWSL2またはDocker内で実行し、Unity EditorがWindows上で動作している場合:
+
+**問題**: WSL2/Docker内の`localhost`はWindowsホストに到達しません。
+
+**解決策**: `host.docker.internal`またはWindowsホストのIPを使用します。
+
+**WSL2/Docker用のClaude Desktop設定（`claude_desktop_config.json`）**:
+
+```json
+{
+  "mcpServers": {
+    "unity-mcp-server": {
+      "command": "npx",
+      "args": ["@akiojin/unity-mcp-server@latest"],
+      "env": {
+        "UNITY_MCP_HOST": "host.docker.internal",
+        "UNITY_PORT": "6400"
+      }
+    }
+  }
+}
+```
+
+**環境変数**:
+
+| 変数 | 説明 | デフォルト |
+|------|------|-----------|
+| `UNITY_MCP_HOST` | MCPサーバーがUnityに接続するためのホスト名 | `localhost` |
+| `UNITY_PORT` | Unity EditorのTCPポート | `6400` |
+| `UNITY_BIND_HOST` | Unityがリッスンするインターフェース（Windows側） | `localhost` |
+
+**Unity Editor設定（Windows）**:
+
+Unity MCP Serverウィンドウ（`MCP Server / Start`）で、ポートが`UNITY_PORT`で設定した値と一致していることを確認してください。デフォルトは6400です。
+
+**WSL2からの接続確認**:
+
+```bash
+# Unityに到達できるか確認
+nc -zv host.docker.internal 6400
+
+# またはホストIPを直接使用
+nc -zv $(cat /etc/resolv.conf | grep nameserver | awk '{print $2}') 6400
+```
+
+### npx初回実行時の遅延
+
+`npx @akiojin/unity-mcp-server@latest`の初回実行時はパッケージのダウンロードに数秒かかります。MCPクライアントがタイムアウトする場合:
+
+**解決策1**: パッケージを事前キャッシュ
+
+```bash
+npx @akiojin/unity-mcp-server@latest --version
+```
+
+**解決策2**: グローバルインストール
+
+```bash
+npm install -g @akiojin/unity-mcp-server
+```
+
+その後、設定を更新してグローバルバイナリを使用:
+
+```json
+{
+  "mcpServers": {
+    "unity-mcp-server": {
+      "command": "unity-mcp-server"
+    }
+  }
+}
+```
+
+### よくある問題
+
+| 症状 | 原因 | 解決策 |
+|------|------|--------|
+| `Connection timeout` | Unity Editor未起動またはホスト/ポート不一致 | Unityが起動中でポートが一致しているか確認 |
+| `ECONNREFUSED` | ファイアウォールがブロックまたはUnityが待受していない | Windowsファイアウォールを確認、Unity MCP Serverが起動しているか確認 |
+| `Unity TCP disconnected`（接続直後に切断） | プロトコル不一致またはUnityがクラッシュ | Unity Consoleでエラーを確認 |
+| `ENOTEMPTY`（npx実行時） | npxキャッシュの破損 | `rm -rf ~/.npm/_npx`を実行して再試行 |
 
 ## リリースプロセス
 

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ Example:
   ```
 
   This is an npm/npx cache corruption issue, not a unity-mcp-server bug.
-- **Connection timeout without Unity Editor**: The MCP server requires Unity Editor to be running with the unity-mcp-server package installed. If Unity is not running, the server will timeout after 30 seconds. Ensure Unity Editor is open with the project containing the package before starting the MCP server.
+- **Unity connection failed**: The MCP server starts and accepts client connections even if Unity Editor is not running. However, tool calls that require Unity (e.g., `screenshot_capture`, `gameobject_create`) will fail with connection errors. The server automatically retries Unity connection in the background. Start Unity Editor with the unity-mcp-server package installed to enable full functionality.
 
 ### Debug Logging
 
@@ -586,6 +586,108 @@ LOG_LEVEL=debug npx @akiojin/unity-mcp-server@latest
 ```
 
 Available log levels: `debug`, `info` (default), `warn`
+
+### Startup Diagnostics
+
+The server outputs diagnostic information to stderr at startup:
+
+```
+[unity-mcp-server] Startup config:
+[unity-mcp-server]   Config file: /path/to/.unity/config.json
+[unity-mcp-server]   Unity host: localhost
+[unity-mcp-server]   Unity port: 6400
+[unity-mcp-server]   Workspace root: /path/to/workspace
+[unity-mcp-server] MCP transport connecting...
+[unity-mcp-server] MCP transport connected
+[unity-mcp-server] Unity TCP connecting to localhost:6400...
+[unity-mcp-server] Unity TCP connected successfully
+```
+
+This helps identify configuration mismatches, especially in cross-platform environments.
+
+### WSL2/Docker to Windows Unity Connection
+
+When running the MCP server inside WSL2 or Docker while Unity Editor runs on Windows:
+
+**Problem**: `localhost` inside WSL2/Docker does not reach the Windows host.
+
+**Solution**: Use `host.docker.internal` or the Windows host IP.
+
+**Claude Desktop config (`claude_desktop_config.json`) for WSL2/Docker**:
+
+```json
+{
+  "mcpServers": {
+    "unity-mcp-server": {
+      "command": "npx",
+      "args": ["@akiojin/unity-mcp-server@latest"],
+      "env": {
+        "UNITY_MCP_HOST": "host.docker.internal",
+        "UNITY_PORT": "6400"
+      }
+    }
+  }
+}
+```
+
+**Environment variables**:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `UNITY_MCP_HOST` | Hostname the MCP server uses to connect to Unity | `localhost` |
+| `UNITY_PORT` | Unity Editor TCP port | `6400` |
+| `UNITY_BIND_HOST` | Interface Unity listens on (Windows side) | `localhost` |
+
+**Unity Editor settings (Windows)**:
+
+In the Unity MCP Server window (`MCP Server / Start`), ensure the port matches what you set in `UNITY_PORT`. Default is 6400.
+
+**Verifying connectivity from WSL2**:
+
+```bash
+# Check if Unity is reachable
+nc -zv host.docker.internal 6400
+
+# Or using the host IP directly
+nc -zv $(cat /etc/resolv.conf | grep nameserver | awk '{print $2}') 6400
+```
+
+### npx First-Run Delay
+
+The first `npx @akiojin/unity-mcp-server@latest` invocation downloads the package, which may take several seconds. If your MCP client times out:
+
+**Solution 1**: Pre-cache the package
+
+```bash
+npx @akiojin/unity-mcp-server@latest --version
+```
+
+**Solution 2**: Install globally
+
+```bash
+npm install -g @akiojin/unity-mcp-server
+```
+
+Then update your config to use the global binary:
+
+```json
+{
+  "mcpServers": {
+    "unity-mcp-server": {
+      "command": "unity-mcp-server"
+    }
+  }
+}
+```
+
+### Common Issues
+
+| Symptom | Cause | Solution |
+|---------|-------|----------|
+| `Connection timeout` | Unity Editor not running or wrong host/port | Check Unity is running and port matches |
+| `ECONNREFUSED` | Firewall blocking or Unity not listening | Check Windows Firewall, verify Unity MCP Server is started |
+| `Unity TCP disconnected` immediately after connect | Protocol mismatch or Unity crashed | Check Unity Console for errors |
+| `ENOTEMPTY` on npx | Stale npx cache | Run `rm -rf ~/.npm/_npx` and retry |
 
 ## Release Process
 

--- a/mcp-server/src/core/config.js
+++ b/mcp-server/src/core/config.js
@@ -301,3 +301,13 @@ if (config.__configLoadError) {
   );
   delete config.__configLoadError;
 }
+
+// Startup debug log: output config info to stderr for troubleshooting
+// This helps diagnose connection issues (especially in WSL2/Docker environments)
+console.error(`[unity-mcp-server] Startup config:`);
+console.error(`[unity-mcp-server]   Config file: ${config.__configPath || '(defaults)'}`);
+console.error(
+  `[unity-mcp-server]   Unity host: ${config.unity.mcpHost || config.unity.unityHost || 'localhost'}`
+);
+console.error(`[unity-mcp-server]   Unity port: ${config.unity.port}`);
+console.error(`[unity-mcp-server]   Workspace root: ${WORKSPACE_ROOT}`);

--- a/mcp-server/src/core/server.js
+++ b/mcp-server/src/core/server.js
@@ -174,8 +174,10 @@ export async function startServer(options = {}) {
     // Create transport - no logging before connection
     let transport;
     if (runtimeConfig.stdioEnabled !== false) {
+      console.error(`[unity-mcp-server] MCP transport connecting...`);
       transport = new HybridStdioServerTransport();
       await server.connect(transport);
+      console.error(`[unity-mcp-server] MCP transport connected`);
     }
 
     // Now safe to log after connection established
@@ -201,9 +203,12 @@ export async function startServer(options = {}) {
     }
 
     // Attempt to connect to Unity
+    console.error(`[unity-mcp-server] Unity connection starting...`);
     try {
       await unityConnection.connect();
+      console.error(`[unity-mcp-server] Unity connection established`);
     } catch (error) {
+      console.error(`[unity-mcp-server] Unity connection failed: ${error.message}`);
       logger.error('Initial Unity connection failed:', error.message);
       logger.info('Unity connection will retry automatically');
     }

--- a/mcp-server/src/core/unityConnection.js
+++ b/mcp-server/src/core/unityConnection.js
@@ -48,6 +48,9 @@ export class UnityConnection extends EventEmitter {
       }
 
       const targetHost = config.unity.mcpHost || config.unity.unityHost;
+      console.error(
+        `[unity-mcp-server] Unity TCP connecting to ${targetHost}:${config.unity.port}...`
+      );
       logger.info(`Connecting to Unity at ${targetHost}:${config.unity.port}...`);
 
       this.socket = new net.Socket();
@@ -74,6 +77,7 @@ export class UnityConnection extends EventEmitter {
 
       // Set up event handlers
       this.socket.on('connect', () => {
+        console.error(`[unity-mcp-server] Unity TCP connected successfully`);
         logger.info('Connected to Unity Editor');
         this.connected = true;
         this.reconnectAttempts = 0;
@@ -93,6 +97,7 @@ export class UnityConnection extends EventEmitter {
       });
 
       this.socket.on('error', error => {
+        console.error(`[unity-mcp-server] Unity TCP error: ${error.message}`);
         logger.error('Socket error:', error.message);
         if (this.listenerCount('error') > 0) {
           this.emit('error', error);
@@ -121,9 +126,11 @@ export class UnityConnection extends EventEmitter {
 
         // Check if we're already handling disconnection
         if (this.isDisconnecting || !this.socket) {
+          console.error(`[unity-mcp-server] Unity TCP close event (already disconnecting)`);
           return;
         }
 
+        console.error(`[unity-mcp-server] Unity TCP disconnected`);
         logger.info('Disconnected from Unity Editor');
         this.connected = false;
         this.socket = null;


### PR DESCRIPTION
## Summary

- Add detailed startup diagnostic logs to help troubleshoot connection issues in WSL2/Docker environments
- Add comprehensive WSL2/Docker configuration guide to README.md and README.ja.md
- Fix incorrect documentation claiming MCP server times out without Unity Editor

## Changes

### Startup Diagnostics
The server now outputs diagnostic information to stderr at startup:
```
[unity-mcp-server] Startup config:
[unity-mcp-server]   Config file: /path/to/.unity/config.json
[unity-mcp-server]   Unity host: localhost
[unity-mcp-server]   Unity port: 6400
[unity-mcp-server]   Workspace root: /path/to/workspace
[unity-mcp-server] MCP transport connecting...
[unity-mcp-server] MCP transport connected
[unity-mcp-server] Unity TCP connecting to localhost:6400...
```

### WSL2/Docker Guide
Added troubleshooting section for users running MCP server in WSL2/Docker connecting to Windows Unity Editor:
- Environment variable configuration (UNITY_MCP_HOST, UNITY_PORT)
- Claude Desktop config example using `host.docker.internal`
- npx caching issues and solutions

### Documentation Fix
Corrected the misleading statement that the server times out without Unity Editor. The MCP server starts and accepts client connections even if Unity is not running - only tool calls requiring Unity will fail.

## Test plan

- [x] All 79 unit tests pass
- [x] Startup diagnostic logs verified in test output
- [x] markdownlint passes on README changes

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)