### PR TITLE
refactor: unify log prefix to [unity-mcp-server]

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/Editor/Logging/McpLogger.cs
+++ b/UnityMCPServer/Packages/unity-mcp-server/Editor/Logging/McpLogger.cs
@@ -4,11 +4,11 @@ namespace UnityMCPServer.Logging
 {
     /// <summary>
     /// Centralized logging utility for Unity MCP Server.
-    /// All log messages are prefixed with [UnityMCPServer] for easy filtering.
+    /// All log messages are prefixed with [unity-mcp-server] for easy filtering.
     /// </summary>
     public static class McpLogger
     {
-        private const string Prefix = "[UnityMCPServer]";
+        private const string Prefix = "[unity-mcp-server]";
 
         public static void Log(string message)
         {

--- a/mcp-server/src/core/config.js
+++ b/mcp-server/src/core/config.js
@@ -92,7 +92,7 @@ const baseConfig = {
   // Logging settings
   logging: {
     level: process.env.LOG_LEVEL || 'info',
-    prefix: '[Unity MCP Server]'
+    prefix: '[unity-mcp-server]'
   },
 
   // HTTP transport (off by default)

--- a/mcp-server/src/core/unityConnection.js
+++ b/mcp-server/src/core/unityConnection.js
@@ -247,7 +247,7 @@ export class UnityConnection extends EventEmitter {
     // Check if this is an unframed Unity debug log
     if (data.length > 0 && !this.messageBuffer.length) {
       const dataStr = data.toString('utf8');
-      if (dataStr.startsWith('[Unity MCP Server]') || dataStr.startsWith('[Unity]')) {
+      if (dataStr.startsWith('[unity-mcp-server]') || dataStr.startsWith('[Unity]')) {
         logger.debug(`[Unity] Received unframed debug log: ${dataStr.trim()}`);
         // Don't process unframed logs as messages
         return;
@@ -322,7 +322,7 @@ export class UnityConnection extends EventEmitter {
 
           // Check if this looks like a Unity log message
           const messageStr = messageData.toString();
-          if (messageStr.includes('[Unity MCP Server]')) {
+          if (messageStr.includes('[unity-mcp-server]')) {
             logger.debug('[Unity] Received Unity log message instead of JSON response');
             // Don't treat this as a critical error
           }

--- a/mcp-server/tests/unit/core/config.test.js
+++ b/mcp-server/tests/unit/core/config.test.js
@@ -30,7 +30,7 @@ describe('Config', () => {
 
     it('should have correct logging settings', () => {
       assert.equal(config.logging.level, 'info');
-      assert.equal(config.logging.prefix, '[Unity MCP Server]');
+      assert.equal(config.logging.prefix, '[unity-mcp-server]');
     });
 
     it('should load mcpHost and unityHost from external config', async () => {
@@ -316,13 +316,13 @@ describe('Config', () => {
     it('should log info messages', () => {
       logger.info('Test info message');
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[Unity MCP Server\] Test info message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] Test info message/);
     });
 
     it('should log error messages', () => {
       logger.error('Test error message');
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[Unity MCP Server\] ERROR: Test error message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] ERROR: Test error message/);
     });
 
     it('should log error with error object', () => {
@@ -345,7 +345,7 @@ describe('Config', () => {
 
       logger.debug('Debug message');
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[Unity MCP Server\] DEBUG: Debug message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] DEBUG: Debug message/);
 
       // Restore original level
       config.logging.level = originalLevel;
@@ -354,7 +354,7 @@ describe('Config', () => {
     it('should log warn messages when level is info', () => {
       logger.warn('Warning message');
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[Unity MCP Server\] WARN: Warning message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] WARN: Warning message/);
     });
 
     it('should log warn messages when level is warn', () => {
@@ -364,7 +364,7 @@ describe('Config', () => {
 
       logger.warn('Warning message');
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[Unity MCP Server\] WARN: Warning message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] WARN: Warning message/);
 
       // Restore original level
       config.logging.level = originalLevel;
@@ -385,7 +385,7 @@ describe('Config', () => {
     it('should handle multiple arguments in logger methods', () => {
       logger.info('Message', { key: 'value' }, 123);
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[Unity MCP Server\] Message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] Message/);
       // Note: The logger uses console.error(...args) which joins them with spaces
       // So the output will contain the stringified object and number
       assert(errorOutput[0].includes('[object Object]') || errorOutput[0].includes('value'));

--- a/mcp-server/tests/unit/core/unityConnection.test.js
+++ b/mcp-server/tests/unit/core/unityConnection.test.js
@@ -321,7 +321,7 @@ describe('UnityConnection', () => {
 
     it('should skip Unity debug logs', () => {
       assert.doesNotThrow(() => {
-        connection.handleData(Buffer.from('[Unity MCP Server] Debug message'));
+        connection.handleData(Buffer.from('[unity-mcp-server] Debug message'));
         connection.handleData(Buffer.from('[Unity] Debug message'));
       });
     });


### PR DESCRIPTION
## Summary

Standardize log prefix across Unity (C#) and Node.js to `[unity-mcp-server]`.

## Changes

| File | Change |
|------|--------|
| `McpLogger.cs` | `[UnityMCPServer]` → `[unity-mcp-server]` |
| `config.js` | `[Unity MCP Server]` → `[unity-mcp-server]` |
| `unityConnection.js` | Unity log detection updated |
| Test files | Updated assertions |

## Rationale

- Matches the npm package name `@akiojin/unity-mcp-server`
- Kebab-case is consistent and easier to filter in logs
- Unifies output from both Unity and Node sides

## Test plan

- [x] All 79 unit tests pass
- [x] Log output verified with unified prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)