### PR TITLE
fix(mcp-server): add bootstrap wrapper for early diagnostic logging

### DIFF
--- a/mcp-server/bin/bootstrap.js
+++ b/mcp-server/bin/bootstrap.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Bootstrap wrapper for unity-mcp-server
+ *
+ * This wrapper ensures:
+ * 1. Early stderr output before any module loading
+ * 2. Global exception handlers are registered first
+ * 3. Module load failures are caught and reported
+ *
+ * ESM static imports are hoisted, so we use dynamic import() to
+ * ensure our error handlers are set up before loading the main module.
+ */
+
+// Synchronous stderr write - this MUST appear before any module loading
+process.stderr.write('[unity-mcp-server] Bootstrap starting...\n');
+
+// Global exception handlers - catch any unhandled errors
+process.on('uncaughtException', err => {
+  process.stderr.write(`[unity-mcp-server] FATAL: Uncaught exception: ${err.message}\n`);
+  process.stderr.write(`${err.stack}\n`);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason, _promise) => {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? reason.stack : '';
+  process.stderr.write(`[unity-mcp-server] FATAL: Unhandled rejection: ${msg}\n`);
+  if (stack) process.stderr.write(`${stack}\n`);
+  process.exit(1);
+});
+
+// Dynamic import to load the main module AFTER error handlers are set up
+// This allows us to catch module load failures
+import('./unity-mcp-server').catch(err => {
+  process.stderr.write(`[unity-mcp-server] FATAL: Module load failed: ${err.message}\n`);
+  process.stderr.write(`${err.stack}\n`);
+  process.exit(1);
+});

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/core/server.js",
   "bin": {
-    "unity-mcp-server": "./bin/unity-mcp-server"
+    "unity-mcp-server": "./bin/bootstrap.js"
   },
   "scripts": {
     "start": "node src/core/server.js",
@@ -29,7 +29,7 @@
     "prebuild:better-sqlite3": "node scripts/prebuild-better-sqlite3.mjs",
     "prebuilt:manifest": "node scripts/generate-prebuilt-manifest.mjs",
     "prepublishOnly": "npm run test:ci && npm run prebuilt:manifest",
-    "postinstall": "node scripts/ensure-better-sqlite3.mjs && chmod +x bin/unity-mcp-server || true",
+    "postinstall": "node scripts/ensure-better-sqlite3.mjs && chmod +x bin/bootstrap.js bin/unity-mcp-server || true",
     "test:ci:unity": "timeout 60 node --test tests/unit/core/codeIndex.test.js tests/unit/core/config.test.js tests/unit/core/indexWatcher.test.js tests/unit/core/projectInfo.test.js tests/unit/core/server.test.js || exit 0",
     "test:unity": "node tests/run-unity-integration.mjs",
     "test:nounity": "npm run test:integration",

--- a/mcp-server/src/core/config.js
+++ b/mcp-server/src/core/config.js
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import * as findUpPkg from 'find-up';
+
+// Diagnostic log: confirm module loading reached this point
+process.stderr.write('[unity-mcp-server] Config module loading...\n');
+
 function findUpSyncCompat(matcher, options = {}) {
   if (typeof matcher === 'function') {
     let dir = options.cwd || process.cwd();


### PR DESCRIPTION
## Summary
- ESM static imports are hoisted, preventing early diagnostic logs from appearing when module loading fails
- Created `bin/bootstrap.js` as a wrapper entry point that uses dynamic `import()` to ensure error handlers are set up before module loading
- Added early diagnostic log output via `process.stderr.write()` for synchronous stderr writes
- Added global exception handlers for `uncaughtException` and `unhandledRejection`

## Changes
- **NEW** `mcp-server/bin/bootstrap.js` - Bootstrap wrapper for early error handling
- `mcp-server/package.json` - Updated bin to point to bootstrap.js
- `mcp-server/src/core/config.js` - Added diagnostic log at module load time

## Expected Output (Success)
```
[unity-mcp-server] Bootstrap starting...
[unity-mcp-server] Config module loading...
[unity-mcp-server] Startup config:
  Config file: .unity/config.json
  Unity host: localhost
  Unity port: 6400
```

## Expected Output (Module Load Failure)
```
[unity-mcp-server] Bootstrap starting...
[unity-mcp-server] FATAL: Module load failed: Cannot find module 'xxx'
```

## Test plan
- [x] All 79 CI tests pass
- [x] Diagnostic logs appear in test output
- [x] ESLint/Prettier checks pass

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)