### PR TITLE
feat(mcp-server): migrate logger to MCP SDK-compliant MCPLogger

### DIFF
--- a/mcp-server/src/core/config.js
+++ b/mcp-server/src/core/config.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import * as findUpPkg from 'find-up';
+import { MCPLogger } from './mcpLogger.js';
 
 // Diagnostic log: confirm module loading reached this point
 process.stderr.write('[unity-mcp-server] Config module loading...\n');
@@ -273,30 +274,11 @@ export const WORKSPACE_ROOT = workspaceRoot;
  * Logger utility
  * IMPORTANT: In MCP servers, all stdout output must be JSON-RPC protocol messages.
  * Logging must go to stderr to avoid breaking the protocol.
+ *
+ * MCP SDK-compliant logger with RFC 5424 log levels.
+ * Supports dual output: stderr (developer) + MCP notification (client)
  */
-export const logger = {
-  info: (message, ...args) => {
-    if (['info', 'debug'].includes(config.logging.level)) {
-      console.error(`${config.logging.prefix} ${message}`, ...args);
-    }
-  },
-
-  warn: (message, ...args) => {
-    if (['info', 'debug', 'warn'].includes(config.logging.level)) {
-      console.error(`${config.logging.prefix} WARN: ${message}`, ...args);
-    }
-  },
-
-  error: (message, ...args) => {
-    console.error(`${config.logging.prefix} ERROR: ${message}`, ...args);
-  },
-
-  debug: (message, ...args) => {
-    if (config.logging.level === 'debug') {
-      console.error(`${config.logging.prefix} DEBUG: ${message}`, ...args);
-    }
-  }
-};
+export const logger = new MCPLogger(config);
 
 // Late log if external config failed to load
 if (config.__configLoadError) {

--- a/mcp-server/src/core/indexBuildWorkerPool.js
+++ b/mcp-server/src/core/indexBuildWorkerPool.js
@@ -68,7 +68,7 @@ export class IndexBuildWorkerPool {
               try {
                 cb(message.data);
               } catch (e) {
-                logger.warn(`[worker-pool] Progress callback error: ${e.message}`);
+                logger.warning(`[worker-pool] Progress callback error: ${e.message}`);
               }
             });
 
@@ -102,7 +102,7 @@ export class IndexBuildWorkerPool {
 
         this.worker.on('exit', code => {
           if (code !== 0 && this.worker) {
-            logger.warn(`[worker-pool] Worker exited with code ${code}`);
+            logger.warning(`[worker-pool] Worker exited with code ${code}`);
             this._cleanup();
             reject(new Error(`Worker exited with code ${code}`));
           }

--- a/mcp-server/src/core/indexWatcher.js
+++ b/mcp-server/src/core/indexWatcher.js
@@ -54,7 +54,7 @@ export class IndexWatcher {
       const driverOk = await probe._ensureDriver();
       if (!driverOk || probe.disabled) {
         const reason = probe.disableReason || 'SQLite native binding not available';
-        logger.warn(`[index] watcher: code index disabled (${reason}); stopping watcher`);
+        logger.warning(`[index] watcher: code index disabled (${reason}); stopping watcher`);
         this.stop();
         return;
       }
@@ -69,7 +69,7 @@ export class IndexWatcher {
       const dbExists = fs.default.existsSync(dbPath);
 
       if (!dbExists) {
-        logger.warn('[index] watcher: code index DB file not found, triggering full rebuild');
+        logger.warning('[index] watcher: code index DB file not found, triggering full rebuild');
         // Force full rebuild when DB file is missing
         const jobId = `watcher-rebuild-${Date.now()}`;
         this.currentWatcherJobId = jobId;
@@ -117,7 +117,7 @@ export class IndexWatcher {
       // (Job result will be logged when it completes/fails)
       this._monitorJob(jobId);
     } catch (e) {
-      logger.warn(`[index] watcher exception: ${e.message}`);
+      logger.warning(`[index] watcher exception: ${e.message}`);
     } finally {
       this.running = false;
     }
@@ -174,7 +174,7 @@ export class IndexWatcher {
         );
         clearInterval(checkInterval);
       } else if (job.status === 'failed') {
-        logger.warn(`[index] watcher: auto-build failed - ${job.error}`);
+        logger.warning(`[index] watcher: auto-build failed - ${job.error}`);
         clearInterval(checkInterval);
       }
     }, 1000);

--- a/mcp-server/src/core/mcpLogger.js
+++ b/mcp-server/src/core/mcpLogger.js
@@ -1,0 +1,182 @@
+/**
+ * MCP SDK-compliant Logger
+ *
+ * RFC 5424 compliant logging with MCP notification support.
+ * Provides 8 log levels: emergency, alert, critical, error, warning, notice, info, debug
+ *
+ * Features:
+ * - Dual output: stderr (developer) + MCP notification (client)
+ * - Dynamic log level control via setLevel()
+ * - Fire-and-forget MCP notifications (non-blocking)
+ * - Error resilience: continues logging even if MCP notification fails
+ */
+
+/**
+ * RFC 5424 log levels (syslog severity)
+ * Lower numbers = higher severity
+ */
+export const LOG_LEVELS = {
+  emergency: 0, // System is unusable
+  alert: 1, // Action must be taken immediately
+  critical: 2, // Critical conditions
+  error: 3, // Error conditions
+  warning: 4, // Warning conditions
+  notice: 5, // Normal but significant condition
+  info: 6, // Informational messages
+  debug: 7 // Debug-level messages
+};
+
+/**
+ * MCP-compliant Logger class
+ */
+export class MCPLogger {
+  /**
+   * @param {Object} config - Configuration object
+   * @param {Object} [config.logging] - Logging configuration
+   * @param {string} [config.logging.prefix='[unity-mcp-server]'] - Log prefix
+   * @param {string} [config.logging.level='info'] - Minimum log level
+   */
+  constructor(config) {
+    this.prefix = config?.logging?.prefix || '[unity-mcp-server]';
+    this.minLevel = LOG_LEVELS[config?.logging?.level || 'info'];
+    this.server = null;
+    this.transportConnected = false;
+  }
+
+  /**
+   * Set MCP Server instance for sending notifications
+   * Should be called after transport is connected
+   * @param {Object} server - MCP Server instance with sendLoggingMessage method
+   */
+  setServer(server) {
+    this.server = server;
+    this.transportConnected = true;
+  }
+
+  /**
+   * Dynamically change log level
+   * @param {string} level - New log level (RFC 5424 level name)
+   */
+  setLevel(level) {
+    if (LOG_LEVELS[level] !== undefined) {
+      this.minLevel = LOG_LEVELS[level];
+    }
+  }
+
+  /**
+   * Internal log method
+   * @param {string} level - Log level
+   * @param {string} message - Log message
+   * @param {...any} args - Additional arguments
+   */
+  _log(level, message, ...args) {
+    const levelNum = LOG_LEVELS[level];
+
+    // Filter by minimum level
+    if (levelNum > this.minLevel) return;
+
+    // 1. Always output to stderr (developer-facing)
+    const formatted = this._formatMessage(level, message);
+    console.error(formatted, ...args);
+
+    // 2. Send MCP notification (client-facing, only when connected)
+    if (this.transportConnected && this.server) {
+      this._sendMcpLog(level, message, args);
+    }
+  }
+
+  /**
+   * Send log message via MCP notification
+   * @param {string} level - Log level
+   * @param {string} message - Log message
+   * @param {any[]} args - Additional arguments
+   */
+  _sendMcpLog(level, message, args) {
+    try {
+      // Concatenate additional arguments into a single string
+      const fullMessage =
+        args.length > 0
+          ? `${message} ${args.map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a))).join(' ')}`
+          : message;
+
+      this.server.sendLoggingMessage({
+        level,
+        logger: 'unity-mcp-server',
+        data: fullMessage // String only (no structured data)
+      });
+    } catch (e) {
+      // Log failure but continue (error resilience)
+      console.error(`${this.prefix} [MCP notification failed] ${e.message}`);
+    }
+  }
+
+  /**
+   * Format message for stderr output
+   * @param {string} level - Log level
+   * @param {string} message - Log message
+   * @returns {string} Formatted message
+   */
+  _formatMessage(level, message) {
+    // info level doesn't include level label (matches existing behavior)
+    const label = level === 'info' ? '' : ` ${level.toUpperCase()}:`;
+    return `${this.prefix}${label} ${message}`;
+  }
+
+  // Public log methods (RFC 5424 levels)
+
+  /**
+   * Emergency: System is unusable
+   */
+  emergency(message, ...args) {
+    this._log('emergency', message, ...args);
+  }
+
+  /**
+   * Alert: Action must be taken immediately
+   */
+  alert(message, ...args) {
+    this._log('alert', message, ...args);
+  }
+
+  /**
+   * Critical: Critical conditions
+   */
+  critical(message, ...args) {
+    this._log('critical', message, ...args);
+  }
+
+  /**
+   * Error: Error conditions
+   */
+  error(message, ...args) {
+    this._log('error', message, ...args);
+  }
+
+  /**
+   * Warning: Warning conditions
+   */
+  warning(message, ...args) {
+    this._log('warning', message, ...args);
+  }
+
+  /**
+   * Notice: Normal but significant condition
+   */
+  notice(message, ...args) {
+    this._log('notice', message, ...args);
+  }
+
+  /**
+   * Info: Informational messages
+   */
+  info(message, ...args) {
+    this._log('info', message, ...args);
+  }
+
+  /**
+   * Debug: Debug-level messages
+   */
+  debug(message, ...args) {
+    this._log('debug', message, ...args);
+  }
+}

--- a/mcp-server/src/core/projectInfo.js
+++ b/mcp-server/src/core/projectInfo.js
@@ -70,7 +70,7 @@ export class ProjectInfoProvider {
           return this.cached;
         }
       } catch (e) {
-        logger.warn(`get_editor_info failed: ${e.message}`);
+        logger.warning(`get_editor_info failed: ${e.message}`);
       }
     }
     if (typeof cfgRootRaw === 'string') {

--- a/mcp-server/src/core/unityConnection.js
+++ b/mcp-server/src/core/unityConnection.js
@@ -300,7 +300,7 @@ export class UnityConnection extends EventEmitter {
         }
 
         if (recoveryIndex > 0) {
-          logger.warn(`[Unity] Discarding ${recoveryIndex} bytes of invalid data`);
+          logger.warning(`[Unity] Discarding ${recoveryIndex} bytes of invalid data`);
           this.messageBuffer = this.messageBuffer.slice(recoveryIndex);
           continue;
         } else {
@@ -323,7 +323,7 @@ export class UnityConnection extends EventEmitter {
 
           // Skip non-JSON messages (like debug logs)
           if (!message.trim().startsWith('{')) {
-            logger.warn(`[Unity] Skipping non-JSON message: ${message.substring(0, 50)}...`);
+            logger.warning(`[Unity] Skipping non-JSON message: ${message.substring(0, 50)}...`);
             continue;
           }
 
@@ -359,7 +359,7 @@ export class UnityConnection extends EventEmitter {
     logger.info(`[Unity] enqueue sendCommand: ${type}`, { connected: this.connected });
 
     if (!this.connected) {
-      logger.warn('[Unity] Not connected; waiting for reconnection before sending command');
+      logger.warning('[Unity] Not connected; waiting for reconnection before sending command');
       await this.ensureConnected({
         timeoutMs: config.unity.commandTimeout
       });
@@ -463,7 +463,7 @@ export class UnityConnection extends EventEmitter {
             result = JSON.parse(result);
             logger.info(`[Unity] Parsed string result as JSON:`, result);
           } catch (parseError) {
-            logger.warn(`[Unity] Failed to parse result as JSON: ${parseError.message}`);
+            logger.warning(`[Unity] Failed to parse result as JSON: ${parseError.message}`);
           }
         }
         if (response.version) result._version = response.version;
@@ -476,7 +476,7 @@ export class UnityConnection extends EventEmitter {
         err.code = response.code;
         pending.reject(err);
       } else {
-        logger.warn(`[Unity] Command ${targetId} has unknown response format`);
+        logger.warning(`[Unity] Command ${targetId} has unknown response format`);
         pending.resolve(response);
       }
       return;

--- a/mcp-server/src/handlers/script/CodeIndexBuildToolHandler.js
+++ b/mcp-server/src/handlers/script/CodeIndexBuildToolHandler.js
@@ -210,7 +210,9 @@ export class CodeIndexBuildToolHandler extends BaseToolHandler {
             // This allows build to continue even if some files fail
             if (processed % 50 === 0) {
               // Log occasionally to avoid spam
-              logger.warn(`[index][${job.id}] Skipped file due to error: ${rel} - ${err.message}`);
+              logger.warning(
+                `[index][${job.id}] Skipped file due to error: ${rel} - ${err.message}`
+              );
             }
           } finally {
             processed += 1;

--- a/mcp-server/src/lsp/CSharpLspUtils.js
+++ b/mcp-server/src/lsp/CSharpLspUtils.js
@@ -92,7 +92,7 @@ export class CSharpLspUtils {
       }
       logger.info(`[csharp-lsp] migrated legacy binary to ${path.dirname(primary)}`);
     } catch (e) {
-      logger.warn(`[csharp-lsp] legacy migration failed: ${e.message}`);
+      logger.warning(`[csharp-lsp] legacy migration failed: ${e.message}`);
     }
   }
 
@@ -135,7 +135,7 @@ export class CSharpLspUtils {
     // バージョン取得失敗時もバイナリが存在すれば使用
     if (!desired) {
       if (fs.existsSync(p)) {
-        logger.warn('[csharp-lsp] version not found, using existing binary');
+        logger.warning('[csharp-lsp] version not found, using existing binary');
         return p;
       }
       throw new Error('mcp-server version not found; cannot resolve LSP tag');
@@ -152,7 +152,7 @@ export class CSharpLspUtils {
       return p;
     } catch (e) {
       if (fs.existsSync(p)) {
-        logger.warn(`[csharp-lsp] download failed, using existing binary: ${e.message}`);
+        logger.warning(`[csharp-lsp] download failed, using existing binary: ${e.message}`);
         return p;
       }
       throw e;

--- a/mcp-server/src/lsp/LspProcessManager.js
+++ b/mcp-server/src/lsp/LspProcessManager.js
@@ -23,7 +23,7 @@ export class LspProcessManager {
         const proc = spawn(bin, { stdio: ['pipe', 'pipe', 'pipe'] });
         proc.on('error', e => logger.error(`[csharp-lsp] process error: ${e.message}`));
         proc.on('close', (code, sig) => {
-          logger.warn(`[csharp-lsp] exited code=${code} signal=${sig || ''}`);
+          logger.warning(`[csharp-lsp] exited code=${code} signal=${sig || ''}`);
           if (this.state.proc === proc) {
             this.state.proc = null;
           }

--- a/mcp-server/src/lsp/LspRpcClient.js
+++ b/mcp-server/src/lsp/LspRpcClient.js
@@ -161,7 +161,7 @@ export class LspRpcClient {
         this.proc = null;
         this.initialized = false;
         this.buf = Buffer.alloc(0);
-        logger.warn(`[csharp-lsp] recoverable error on ${method}: ${msg}. Retrying once...`);
+        logger.warning(`[csharp-lsp] recoverable error on ${method}: ${msg}. Retrying once...`);
         return await this.#requestWithRetry(method, params, attempt + 1);
       }
       // Standardize error message

--- a/mcp-server/src/lsp/LspRpcClientSingleton.js
+++ b/mcp-server/src/lsp/LspRpcClientSingleton.js
@@ -42,7 +42,7 @@ export class LspRpcClientSingleton {
       try {
         await instance.mgr.stop();
       } catch (e) {
-        logger.warn(`[LspRpcClientSingleton] error stopping: ${e.message}`);
+        logger.warning(`[LspRpcClientSingleton] error stopping: ${e.message}`);
       }
       instance = null;
       currentProjectRoot = null;
@@ -59,7 +59,7 @@ export class LspRpcClientSingleton {
       if (!instance) return;
       // Check if process is still alive before attempting heartbeat
       if (!instance.proc || instance.proc.killed) {
-        logger.warn('[LspRpcClientSingleton] process dead, resetting...');
+        logger.warning('[LspRpcClientSingleton] process dead, resetting...');
         instance = null;
         currentProjectRoot = null;
         LspRpcClientSingleton.#stopHeartbeat();
@@ -69,7 +69,7 @@ export class LspRpcClientSingleton {
         // Use workspace/symbol with empty query as a lightweight ping
         await instance.request('workspace/symbol', { query: '' });
       } catch (e) {
-        logger.warn(`[LspRpcClientSingleton] heartbeat failed: ${e.message}, resetting...`);
+        logger.warning(`[LspRpcClientSingleton] heartbeat failed: ${e.message}, resetting...`);
         // Process is dead, reset instance for next request
         instance = null;
         currentProjectRoot = null;

--- a/mcp-server/src/utils/testResultsCache.js
+++ b/mcp-server/src/utils/testResultsCache.js
@@ -30,7 +30,9 @@ export async function persistTestResults(result) {
     await fs.writeFile(filePath, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
     return filePath;
   } catch (error) {
-    logger.warn(`[TestResultsCache] Failed to write test results to ${filePath}: ${error.message}`);
+    logger.warning(
+      `[TestResultsCache] Failed to write test results to ${filePath}: ${error.message}`
+    );
     return null;
   }
 }
@@ -46,7 +48,7 @@ export async function loadCachedTestResults(targetPath) {
     return JSON.parse(data);
   } catch (error) {
     if (error.code !== 'ENOENT') {
-      logger.warn(
+      logger.warning(
         `[TestResultsCache] Failed to read test results from ${filePath}: ${error.message}`
       );
     }
@@ -63,7 +65,7 @@ export async function resetTestResultsCache() {
   try {
     await fs.rm(filePath, { force: true });
   } catch (error) {
-    logger.warn(
+    logger.warning(
       `[TestResultsCache] Failed to reset test results cache ${filePath}: ${error.message}`
     );
   }

--- a/mcp-server/src/utils/testRunState.js
+++ b/mcp-server/src/utils/testRunState.js
@@ -27,7 +27,7 @@ await (async () => {
     logger.info(`[testRunState] Loaded persisted state from ${runStatePath}`);
   } catch (error) {
     if (error.code !== 'ENOENT') {
-      logger.warn(`[testRunState] Failed to load state from ${runStatePath}: ${error.message}`);
+      logger.warning(`[testRunState] Failed to load state from ${runStatePath}: ${error.message}`);
     }
   }
 })();
@@ -85,6 +85,6 @@ async function persist() {
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(runStatePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
   } catch (error) {
-    logger.warn(`[testRunState] Failed to persist state to ${runStatePath}: ${error.message}`);
+    logger.warning(`[testRunState] Failed to persist state to ${runStatePath}: ${error.message}`);
   }
 }

--- a/mcp-server/tests/unit/core/config.test.js
+++ b/mcp-server/tests/unit/core/config.test.js
@@ -339,47 +339,44 @@ describe('Config', () => {
     });
 
     it('should log debug messages when level is debug', () => {
-      // Temporarily change log level
-      const originalLevel = config.logging.level;
-      config.logging.level = 'debug';
+      // Use setLevel to dynamically change log level
+      logger.setLevel('debug');
 
       logger.debug('Debug message');
       assert.equal(errorOutput.length, 1);
       assert.match(errorOutput[0], /\[unity-mcp-server\] DEBUG: Debug message/);
 
       // Restore original level
-      config.logging.level = originalLevel;
+      logger.setLevel('info');
     });
 
-    it('should log warn messages when level is info', () => {
-      logger.warn('Warning message');
+    it('should log warning messages when level is info', () => {
+      logger.warning('Warning message');
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[unity-mcp-server\] WARN: Warning message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] WARNING: Warning message/);
     });
 
-    it('should log warn messages when level is warn', () => {
-      // Temporarily change log level
-      const originalLevel = config.logging.level;
-      config.logging.level = 'warn';
+    it('should log warning messages when level is warning', () => {
+      // Use setLevel to dynamically change log level
+      logger.setLevel('warning');
 
-      logger.warn('Warning message');
+      logger.warning('Warning message');
       assert.equal(errorOutput.length, 1);
-      assert.match(errorOutput[0], /\[unity-mcp-server\] WARN: Warning message/);
+      assert.match(errorOutput[0], /\[unity-mcp-server\] WARNING: Warning message/);
 
       // Restore original level
-      config.logging.level = originalLevel;
+      logger.setLevel('info');
     });
 
-    it('should not log info messages when level is warn', () => {
-      // Temporarily change log level
-      const originalLevel = config.logging.level;
-      config.logging.level = 'warn';
+    it('should not log info messages when level is warning', () => {
+      // Use setLevel to dynamically change log level
+      logger.setLevel('warning');
 
       logger.info('Info message');
       assert.equal(errorOutput.length, 0);
 
       // Restore original level
-      config.logging.level = originalLevel;
+      logger.setLevel('info');
     });
 
     it('should handle multiple arguments in logger methods', () => {
@@ -393,20 +390,18 @@ describe('Config', () => {
     });
 
     it('should always log error messages regardless of level', () => {
-      // Test with different log levels
-      const originalLevel = config.logging.level;
-
-      config.logging.level = 'debug';
+      // Test with different log levels using setLevel
+      logger.setLevel('debug');
       logger.error('Error message 1');
       assert.equal(errorOutput.length, 1);
 
       errorOutput.length = 0; // Clear
-      config.logging.level = 'warn';
+      logger.setLevel('warning');
       logger.error('Error message 2');
       assert.equal(errorOutput.length, 1);
 
       // Restore original level
-      config.logging.level = originalLevel;
+      logger.setLevel('info');
     });
 
     it('should handle error objects in logger.error', () => {

--- a/mcp-server/tests/unit/core/mcpLogger.test.js
+++ b/mcp-server/tests/unit/core/mcpLogger.test.js
@@ -1,0 +1,338 @@
+/**
+ * MCPLogger unit tests
+ *
+ * Tests for MCP SDK-compliant logging functionality
+ * RFC 5424 log levels: emergency, alert, critical, error, warning, notice, info, debug
+ */
+
+import assert from 'node:assert';
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import { MCPLogger, LOG_LEVELS } from '../../../src/core/mcpLogger.js';
+
+describe('MCPLogger', () => {
+  let originalConsoleError;
+  let consoleOutput;
+
+  beforeEach(() => {
+    // Capture console.error output
+    originalConsoleError = console.error;
+    consoleOutput = [];
+    console.error = (...args) => {
+      consoleOutput.push(args);
+    };
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  describe('LOG_LEVELS', () => {
+    // REQ-1: RFC 5424準拠の8段階ログレベルをサポート
+    it('should define all 8 RFC 5424 log levels', () => {
+      assert.strictEqual(LOG_LEVELS.emergency, 0);
+      assert.strictEqual(LOG_LEVELS.alert, 1);
+      assert.strictEqual(LOG_LEVELS.critical, 2);
+      assert.strictEqual(LOG_LEVELS.error, 3);
+      assert.strictEqual(LOG_LEVELS.warning, 4);
+      assert.strictEqual(LOG_LEVELS.notice, 5);
+      assert.strictEqual(LOG_LEVELS.info, 6);
+      assert.strictEqual(LOG_LEVELS.debug, 7);
+    });
+
+    it('should have exactly 8 levels', () => {
+      assert.strictEqual(Object.keys(LOG_LEVELS).length, 8);
+    });
+  });
+
+  describe('constructor', () => {
+    it('should use default prefix when not provided', () => {
+      const logger = new MCPLogger({});
+      assert.strictEqual(logger.prefix, '[unity-mcp-server]');
+    });
+
+    it('should use custom prefix when provided', () => {
+      const logger = new MCPLogger({ logging: { prefix: '[custom]' } });
+      assert.strictEqual(logger.prefix, '[custom]');
+    });
+
+    it('should use default log level (info) when not provided', () => {
+      const logger = new MCPLogger({});
+      assert.strictEqual(logger.minLevel, LOG_LEVELS.info);
+    });
+
+    it('should use custom log level when provided', () => {
+      const logger = new MCPLogger({ logging: { level: 'debug' } });
+      assert.strictEqual(logger.minLevel, LOG_LEVELS.debug);
+    });
+
+    it('should start with server and transportConnected as null/false', () => {
+      const logger = new MCPLogger({});
+      assert.strictEqual(logger.server, null);
+      assert.strictEqual(logger.transportConnected, false);
+    });
+  });
+
+  describe('setServer', () => {
+    it('should set server instance and mark transport as connected', () => {
+      const logger = new MCPLogger({});
+      const mockServer = { sendLoggingMessage: () => {} };
+
+      logger.setServer(mockServer);
+
+      assert.strictEqual(logger.server, mockServer);
+      assert.strictEqual(logger.transportConnected, true);
+    });
+  });
+
+  describe('setLevel', () => {
+    it('should change log level to valid level', () => {
+      const logger = new MCPLogger({});
+      logger.setLevel('debug');
+      assert.strictEqual(logger.minLevel, LOG_LEVELS.debug);
+
+      logger.setLevel('error');
+      assert.strictEqual(logger.minLevel, LOG_LEVELS.error);
+    });
+
+    it('should ignore invalid log level', () => {
+      const logger = new MCPLogger({ logging: { level: 'info' } });
+      logger.setLevel('invalid');
+      assert.strictEqual(logger.minLevel, LOG_LEVELS.info);
+    });
+  });
+
+  describe('log level filtering (REQ-2)', () => {
+    it('should output logs at or below minLevel', () => {
+      const logger = new MCPLogger({ logging: { level: 'warning' } });
+
+      logger.emergency('test');
+      logger.alert('test');
+      logger.critical('test');
+      logger.error('test');
+      logger.warning('test');
+
+      assert.strictEqual(consoleOutput.length, 5);
+    });
+
+    it('should filter logs above minLevel', () => {
+      const logger = new MCPLogger({ logging: { level: 'warning' } });
+
+      logger.notice('test');
+      logger.info('test');
+      logger.debug('test');
+
+      assert.strictEqual(consoleOutput.length, 0);
+    });
+
+    it('should output all levels when minLevel is debug', () => {
+      const logger = new MCPLogger({ logging: { level: 'debug' } });
+
+      logger.emergency('test');
+      logger.alert('test');
+      logger.critical('test');
+      logger.error('test');
+      logger.warning('test');
+      logger.notice('test');
+      logger.info('test');
+      logger.debug('test');
+
+      assert.strictEqual(consoleOutput.length, 8);
+    });
+  });
+
+  describe('stderr output (REQ-3)', () => {
+    it('should always output to stderr via console.error', () => {
+      const logger = new MCPLogger({});
+      logger.info('test message');
+
+      assert.strictEqual(consoleOutput.length, 1);
+    });
+
+    it('should format message with prefix', () => {
+      const logger = new MCPLogger({ logging: { prefix: '[test]' } });
+      logger.info('hello world');
+
+      assert.ok(consoleOutput[0][0].includes('[test]'));
+      assert.ok(consoleOutput[0][0].includes('hello world'));
+    });
+
+    it('should include level label for non-info levels', () => {
+      // Set debug level to ensure all logs are output
+      const logger = new MCPLogger({ logging: { level: 'debug' } });
+
+      logger.error('error msg');
+      logger.warning('warning msg');
+      logger.debug('debug msg');
+
+      // error, warning, debug should have level labels
+      assert.ok(consoleOutput[0][0].includes('ERROR:'));
+      assert.ok(consoleOutput[1][0].includes('WARNING:'));
+      assert.ok(consoleOutput[2][0].includes('DEBUG:'));
+    });
+
+    it('should not include level label for info level', () => {
+      const logger = new MCPLogger({});
+      logger.info('info msg');
+
+      assert.ok(!consoleOutput[0][0].includes('INFO:'));
+    });
+
+    it('should pass additional arguments to console.error', () => {
+      const logger = new MCPLogger({});
+      const extraData = { key: 'value' };
+      logger.info('message', extraData);
+
+      assert.strictEqual(consoleOutput[0].length, 2);
+      assert.deepStrictEqual(consoleOutput[0][1], extraData);
+    });
+  });
+
+  describe('MCP notification (REQ-4)', () => {
+    it('should not send MCP notification when transport is not connected', () => {
+      const logger = new MCPLogger({});
+      let notificationSent = false;
+
+      // Server is not set, so no notification should be sent
+      logger.info('test');
+
+      assert.strictEqual(notificationSent, false);
+    });
+
+    it('should send MCP notification when transport is connected', () => {
+      const logger = new MCPLogger({});
+      let notificationParams = null;
+      const mockServer = {
+        sendLoggingMessage: params => {
+          notificationParams = params;
+        }
+      };
+
+      logger.setServer(mockServer);
+      logger.info('test message');
+
+      assert.ok(notificationParams);
+      assert.strictEqual(notificationParams.level, 'info');
+      assert.strictEqual(notificationParams.logger, 'unity-mcp-server');
+    });
+  });
+
+  describe('MCP notification data format (REQ-5)', () => {
+    it('should send message as string in data field', () => {
+      const logger = new MCPLogger({});
+      let notificationParams = null;
+      const mockServer = {
+        sendLoggingMessage: params => {
+          notificationParams = params;
+        }
+      };
+
+      logger.setServer(mockServer);
+      logger.info('simple message');
+
+      assert.strictEqual(typeof notificationParams.data, 'string');
+      assert.strictEqual(notificationParams.data, 'simple message');
+    });
+
+    it('should concatenate additional arguments into data string', () => {
+      const logger = new MCPLogger({});
+      let notificationParams = null;
+      const mockServer = {
+        sendLoggingMessage: params => {
+          notificationParams = params;
+        }
+      };
+
+      logger.setServer(mockServer);
+      logger.info('message', 'arg1', { key: 'value' });
+
+      assert.strictEqual(typeof notificationParams.data, 'string');
+      assert.ok(notificationParams.data.includes('message'));
+      assert.ok(notificationParams.data.includes('arg1'));
+      assert.ok(notificationParams.data.includes('key'));
+    });
+  });
+
+  describe('error resilience (REQ-8)', () => {
+    it('should continue stderr output even when MCP notification fails', () => {
+      const logger = new MCPLogger({});
+      const mockServer = {
+        sendLoggingMessage: () => {
+          throw new Error('MCP notification failed');
+        }
+      };
+
+      logger.setServer(mockServer);
+
+      // Should not throw
+      assert.doesNotThrow(() => {
+        logger.info('test message');
+      });
+
+      // stderr output should still happen (message + error notification)
+      assert.ok(consoleOutput.length >= 1);
+    });
+
+    it('should log MCP notification failure to stderr', () => {
+      const logger = new MCPLogger({});
+      const mockServer = {
+        sendLoggingMessage: () => {
+          throw new Error('Network error');
+        }
+      };
+
+      logger.setServer(mockServer);
+      logger.info('test');
+
+      // Check that error was logged
+      const hasErrorLog = consoleOutput.some(output =>
+        output[0].includes('MCP notification failed')
+      );
+      assert.ok(hasErrorLog);
+    });
+  });
+
+  describe('public methods', () => {
+    it('should have all 8 log level methods', () => {
+      const logger = new MCPLogger({});
+
+      assert.strictEqual(typeof logger.emergency, 'function');
+      assert.strictEqual(typeof logger.alert, 'function');
+      assert.strictEqual(typeof logger.critical, 'function');
+      assert.strictEqual(typeof logger.error, 'function');
+      assert.strictEqual(typeof logger.warning, 'function');
+      assert.strictEqual(typeof logger.notice, 'function');
+      assert.strictEqual(typeof logger.info, 'function');
+      assert.strictEqual(typeof logger.debug, 'function');
+    });
+
+    it('should send correct level in MCP notification for each method', () => {
+      const logger = new MCPLogger({ logging: { level: 'debug' } });
+      const notifications = [];
+      const mockServer = {
+        sendLoggingMessage: params => {
+          notifications.push(params);
+        }
+      };
+
+      logger.setServer(mockServer);
+
+      logger.emergency('test');
+      logger.alert('test');
+      logger.critical('test');
+      logger.error('test');
+      logger.warning('test');
+      logger.notice('test');
+      logger.info('test');
+      logger.debug('test');
+
+      assert.strictEqual(notifications[0].level, 'emergency');
+      assert.strictEqual(notifications[1].level, 'alert');
+      assert.strictEqual(notifications[2].level, 'critical');
+      assert.strictEqual(notifications[3].level, 'error');
+      assert.strictEqual(notifications[4].level, 'warning');
+      assert.strictEqual(notifications[5].level, 'notice');
+      assert.strictEqual(notifications[6].level, 'info');
+      assert.strictEqual(notifications[7].level, 'debug');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

MCP SDK準拠のロギング機能への完全移行。

- RFC 5424準拠の8段階ログレベル対応（emergency, alert, critical, error, warning, notice, info, debug）
- MCPクライアント（Claude等）へのリアルタイムログ通知（`sendLoggingMessage`）
- `logging/setLevel`リクエストによるログレベル動的変更
- 既存のstderr出力（開発者向け）も維持

## Changes

- **新規作成**: `src/core/mcpLogger.js` - MCP SDK準拠のロガークラス
- **新規作成**: `tests/unit/core/mcpLogger.test.js` - 26件のユニットテスト
- **更新**: `src/core/config.js` - MCPLoggerインスタンスを使用
- **更新**: `src/core/server.js` - `capabilities.logging`追加、`setLevel`ハンドラー実装
- **置換**: 全30箇所の`logger.warn()` → `logger.warning()`

## Test plan

- [x] MCPLogger単体テスト（26件パス）
- [x] config.jsテスト（11件パス）
- [x] 全ユニットテスト（79件パス）
- [x] Linter/Formatter通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)