### PR TITLE
fix(mcp-server): always use Content-Length framing for output

### DIFF
--- a/mcp-server/src/core/transports/HybridStdioServerTransport.js
+++ b/mcp-server/src/core/transports/HybridStdioServerTransport.js
@@ -11,10 +11,6 @@ function encodeContentLength(message) {
   return header + json;
 }
 
-function encodeNdjson(message) {
-  return `${JSON.stringify(message)}\n`;
-}
-
 function parseJson(text) {
   return JSONRPCMessageSchema.parse(JSON.parse(text));
 }
@@ -63,8 +59,9 @@ export class HybridStdioServerTransport {
 
   send(message) {
     return new Promise(resolve => {
-      const payload =
-        this._mode === 'ndjson' ? encodeNdjson(message) : encodeContentLength(message);
+      // Always use Content-Length framing for output (MCP protocol standard)
+      // Input remains hybrid (Content-Length or NDJSON) for client compatibility
+      const payload = encodeContentLength(message);
       if (this._stdout.write(payload)) {
         resolve();
       } else {

--- a/mcp-server/tests/unit/core/transports/HybridStdioServerTransport.test.js
+++ b/mcp-server/tests/unit/core/transports/HybridStdioServerTransport.test.js
@@ -52,7 +52,8 @@ describe('HybridStdioServerTransport', () => {
     assert.match(output, /^Content-Length: \d+\r\n\r\n/);
   });
 
-  it('parses NDJSON framed messages and responds without headers', async () => {
+  it('parses NDJSON framed messages and still responds with Content-Length', async () => {
+    // Input can be NDJSON, but output is always Content-Length (MCP protocol standard)
     stdin.write('{"jsonrpc":"2.0","id":2,"method":"ping"}\n');
 
     await waitForMicrotask();
@@ -63,8 +64,8 @@ describe('HybridStdioServerTransport', () => {
 
     await transport.send({ jsonrpc: '2.0', id: 2, result: {} });
     const output = Buffer.concat(written).toString('utf8');
-    assert.doesNotMatch(output, /^Content-Length:/);
-    assert.ok(output.trimEnd().endsWith('}'));
+    // Output must always use Content-Length framing regardless of input format
+    assert.match(output, /^Content-Length: \d+\r\n\r\n/);
   });
 
   it('accepts Content-Length headers terminated with LF only', async () => {


### PR DESCRIPTION
## Summary

- Fix HybridStdioServerTransport to always use Content-Length framing for output
- This resolves the timeout issue when Claude Code connects via npx

## Root Cause

HybridStdioServerTransport was mixing Content-Length and NDJSON framing in the same session:

1. When `_mode` was null (before first client message), `send()` used Content-Length
2. After receiving NDJSON input, `_mode` was set to 'ndjson'
3. Subsequent messages (including initialize response) were sent as NDJSON
4. This caused Content-Length/NDJSON mixing in the same session
5. Claude Code expects Content-Length format and couldn't parse the initialize response

## Fix

- `send()` now always uses Content-Length framing (MCP protocol standard)
- Input parsing remains hybrid (Content-Length or NDJSON) for client compatibility
- Removed unused `encodeNdjson` function

## Test Plan

- [x] All 4 transport tests pass
- [x] All 79 CI tests pass
- [x] Hex dump verification shows all messages now have Content-Length headers

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)