### PR TITLE
fix(mcp-server): resolve fast-sql dependency for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,8 +201,8 @@ jobs:
             dist/**/csharp-lsp-*
             csharp-lsp-manifest.json
 
-  npm-publish:
-    name: Publish to npm
+  npm-publish-fast-sql:
+    name: Publish fast-sql to npm
     needs: build-csharp-lsp
     runs-on: ubuntu-latest
     env:
@@ -222,7 +222,65 @@ jobs:
       - name: Get release tag
         id: tag
         run: |
-          TAG="${{ env.RELEASE_TAG }}"
+          TAG="${RELEASE_TAG}"
+          if [ -z "$TAG" ]; then
+            TAG=$(git describe --tags --abbrev=0)
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Check if fast-sql needs publishing
+        id: check
+        working-directory: packages/fast-sql
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VER=$(node -p "require('./package.json').version")
+          if npm view "${PKG_NAME}@${PKG_VER}" version 2>/dev/null; then
+            echo "Version $PKG_VER already published, skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version $PKG_VER not found, will publish"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.skip == 'false'
+        working-directory: packages/fast-sql
+        run: npm install
+
+      - name: Build fast-sql
+        if: steps.check.outputs.skip == 'false'
+        working-directory: packages/fast-sql
+        run: npm run build
+
+      - name: Publish fast-sql to npm
+        if: steps.check.outputs.skip == 'false'
+        working-directory: packages/fast-sql
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+  npm-publish:
+    name: Publish to npm
+    needs: [build-csharp-lsp, npm-publish-fast-sql]
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get release tag
+        id: tag
+        run: |
+          TAG="${RELEASE_TAG}"
           if [ -z "$TAG" ]; then
             TAG=$(git describe --tags --abbrev=0)
           fi
@@ -230,8 +288,9 @@ jobs:
 
       - name: Verify version matches tag
         working-directory: mcp-server
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
           PKG_VER=$(node -p "require('./package.json').version")
           if [ "v$PKG_VER" != "$TAG" ]; then
             echo "Version mismatch: tag($TAG) != package($PKG_VER)" >&2
@@ -241,9 +300,9 @@ jobs:
       - name: Wait for csharp-lsp manifest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
-          TAG="${{ steps.tag.outputs.tag }}"
-          REPO="${{ github.repository }}"
           for i in $(seq 1 60); do
             if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
               NAMES=$(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name' || true)
@@ -255,6 +314,21 @@ jobs:
             sleep 10
           done
           echo "Manifest not found after 10 minutes" >&2
+          exit 1
+
+      - name: Wait for fast-sql availability
+        run: |
+          FAST_SQL_VER=$(node -p "require('./packages/fast-sql/package.json').version")
+          echo "Waiting for @akiojin/fast-sql@$FAST_SQL_VER to be available..."
+          for i in $(seq 1 30); do
+            if npm view "@akiojin/fast-sql@$FAST_SQL_VER" version 2>/dev/null; then
+              echo "fast-sql $FAST_SQL_VER is available"
+              exit 0
+            fi
+            echo "Attempt $i: not yet available, waiting..."
+            sleep 10
+          done
+          echo "fast-sql not available after 5 minutes" >&2
           exit 1
 
       - name: Install dependencies

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.3",
     "find-up": "^6.3.0",
-    "@akiojin/fast-sql": "file:../packages/fast-sql"
+    "@akiojin/fast-sql": "^0.1.0"
   },
   "engines": {
     "node": ">=18 <23"

--- a/packages/fast-sql/package.json
+++ b/packages/fast-sql/package.json
@@ -45,8 +45,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "better-sqlite3": "^12.5.0",
     "sql.js": "^1.13.0"
+  },
+  "optionalDependencies": {
+    "better-sqlite3": "^12.5.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.8",


### PR DESCRIPTION
## Summary

Issue #210対応: `file:../packages/fast-sql`パスはnpmパッケージ公開時に解決できないため、`@akiojin/fast-sql`を別パッケージとしてnpmに公開する方式に変更しました。

### 変更内容

1. **publish.ymlワークフロー拡張**
   - `npm-publish-fast-sql`ジョブを追加
   - 既存バージョンが公開済みの場合はスキップ（冪等性）
   - `npm-publish`はfast-sqlの公開完了を待ってから実行

2. **mcp-server依存関係の修正**
   - `file:../packages/fast-sql` → `^0.1.0`（npm版）
   - 次回リリースでfast-sqlが先にnpmへ公開され、その後mcp-serverが公開される

3. **fast-sql optionalDependencies**
   - `better-sqlite3`をoptionalDependenciesに移動
   - ネイティブビルドが失敗してもsql.jsにフォールバック

## Test plan

- [x] mcp-serverのCIテスト（68件パス）
- [ ] GitHub Actionsでのfast-sql公開確認（次回タグ作成時）

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)