### PR TITLE
fix(code-index): throw error on saveDatabase failure and validate DB file existence

### DIFF
--- a/mcp-server/src/core/codeIndex.js
+++ b/mcp-server/src/core/codeIndex.js
@@ -72,8 +72,17 @@ export class CodeIndex {
 
     // Use shared connection for all CodeIndex instances
     if (sharedConnections.db && sharedConnections.dbPath === dbPath) {
-      this.db = sharedConnections.db;
-      return this.db;
+      // Verify the DB file still exists before returning cached connection
+      if (!fs.existsSync(dbPath)) {
+        // File was deleted or never created, invalidate cache
+        logger.info('[index] DB file missing, invalidating cached connection');
+        sharedConnections.db = null;
+        sharedConnections.dbPath = null;
+        sharedConnections.schemaInitialized = false;
+      } else {
+        this.db = sharedConnections.db;
+        return this.db;
+      }
     }
 
     try {

--- a/mcp-server/src/core/workers/indexBuildWorker.js
+++ b/mcp-server/src/core/workers/indexBuildWorker.js
@@ -31,9 +31,24 @@ function saveDatabase(db, dbPath) {
   try {
     const data = db.exportDb();
     const buffer = Buffer.from(data);
+
+    // Ensure parent directory exists
+    const dir = path.dirname(dbPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
     fs.writeFileSync(dbPath, buffer);
+
+    // Verify file was written
+    if (!fs.existsSync(dbPath)) {
+      throw new Error('Database file was not created');
+    }
+
+    log('info', `[worker] Database saved successfully: ${dbPath} (${buffer.length} bytes)`);
   } catch (e) {
-    log('warn', `[worker] Failed to save database: ${e.message}`);
+    log('error', `[worker] Failed to save database: ${e.message}`);
+    throw e; // Re-throw to fail the build
   }
 }
 


### PR DESCRIPTION
## Summary

- saveDatabase() でエラー発生時に throw して Worker をエラー終了させる
- 親ディレクトリが存在しない場合は自動作成
- 書き込み後にファイル存在を検証
- codeIndex.open() でキャッシュ返却前にファイル存在チェックを追加

## Root Cause

Issue #210 で報告された状態不整合問題:
1. saveDatabase() がエラーを握りつぶし、Worker が「成功」として完了報告
2. codeIndex.open() がファイル存在を検証せずにキャッシュされた DB を返す
3. 結果: ステータスは「ready: true」だが、DB ファイルが存在しない

## Changes

- `mcp-server/src/core/workers/indexBuildWorker.js`: saveDatabase() のエラーハンドリング強化
- `mcp-server/src/core/codeIndex.js`: open() でファイル存在チェック追加

## Test plan

- [ ] DB 保存失敗時に Worker がエラーで終了すること
- [ ] DB ファイルが存在しない場合、`code_index_status` が `ready: false` を返すこと
- [ ] 正常なビルド後、DB ファイルが作成されていること

Issue #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* データベース接続時のキャッシュ検証を強化し、ファイルの存在確認を追加しました
* データベース保存処理の堅牢性を向上させ、ディレクトリの事前作成とファイル検証を実装しました
* エラーハンドリングを改善し、失敗時のログ出力と例外処理をより適切に対応するようにしました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->