### PR TITLE
Dockerfileでgh拡張インストール時のトークン受け渡しを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   unity-mcp-server:
-    build: .
+    build:
+      context: .
+      args:
+        GH_TOKEN: ${GH_TOKEN:-}
+        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     container_name: unity-mcp-server
     volumes:
       - .:/unity-mcp-server


### PR DESCRIPTION
- Dockerfileにビルド引数としてGH_TOKEN/GITHUB_TOKENを追加し、gh拡張インストール時に明示的に渡すようにしました。
- docker-compose.ymlでbuild.argsにGH_TOKEN/GITHUB_TOKENを設定し、ホストの環境変数から渡せるようにしました。

ビルド時にGH_TOKENまたはGITHUB_TOKENが未指定の場合は早期にエラーにして原因を明示します。