### PR TITLE
feat(code-index): add [OFFLINE] tag to tool descriptions for LLM awareness

### DIFF
--- a/mcp-server/src/constants/offlineTools.js
+++ b/mcp-server/src/constants/offlineTools.js
@@ -1,0 +1,19 @@
+/**
+ * List of tools that work without Unity connection.
+ * These tools use only the local C# LSP and file system.
+ */
+export const OFFLINE_TOOLS = [
+  'code_index_status',
+  'code_index_build',
+  'code_index_update',
+  'script_symbols_get',
+  'script_symbol_find',
+  'script_refs_find',
+  'script_read',
+  'script_search',
+  'script_packages_list'
+];
+
+export const OFFLINE_TOOLS_HINT =
+  'Code index and script analysis tools work without Unity connection. ' +
+  'Use these tools for C# code exploration, symbol search, and editing.';

--- a/mcp-server/src/handlers/script/CodeIndexBuildToolHandler.js
+++ b/mcp-server/src/handlers/script/CodeIndexBuildToolHandler.js
@@ -8,7 +8,7 @@ export class CodeIndexBuildToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'code_index_build',
-      'Build (or rebuild) the persistent SQLite symbol index by scanning document symbols via the C# LSP. Returns immediately with jobId for background execution. Check progress with code_index_status. Stores DB under .unity/cache/code-index/code-index.db.',
+      '[OFFLINE] No Unity connection required. Build (or rebuild) the persistent SQLite symbol index by scanning document symbols via the C# LSP. Returns immediately with jobId for background execution. Check progress with code_index_status. Stores DB under .unity/cache/code-index/code-index.db.',
       {
         type: 'object',
         properties: {

--- a/mcp-server/src/handlers/script/CodeIndexStatusToolHandler.js
+++ b/mcp-server/src/handlers/script/CodeIndexStatusToolHandler.js
@@ -6,7 +6,7 @@ export class CodeIndexStatusToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'code_index_status',
-      'Report code index status and readiness for symbol/search operations. BEST PRACTICES: Check before heavy symbol operations. Shows total files indexed and coverage percentage. If coverage is low, some symbol operations may be incomplete. Index is automatically built on first use. No parameters needed - lightweight status check.',
+      '[OFFLINE] No Unity connection required. Report code index status and readiness for symbol/search operations. BEST PRACTICES: Check before heavy symbol operations. Shows total files indexed and coverage percentage. If coverage is low, some symbol operations may be incomplete. Index is automatically built on first use. No parameters needed - lightweight status check.',
       {
         type: 'object',
         properties: {},

--- a/mcp-server/src/handlers/script/CodeIndexUpdateToolHandler.js
+++ b/mcp-server/src/handlers/script/CodeIndexUpdateToolHandler.js
@@ -17,7 +17,7 @@ export class CodeIndexUpdateToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'code_index_update',
-      'Refresh code index entries for specific C# files. Use this after modifying files so script editing tools see the latest symbols.',
+      '[OFFLINE] No Unity connection required. Refresh code index entries for specific C# files. Use this after modifying files so script editing tools see the latest symbols.',
       {
         type: 'object',
         properties: {

--- a/mcp-server/src/handlers/script/ScriptPackagesListToolHandler.js
+++ b/mcp-server/src/handlers/script/ScriptPackagesListToolHandler.js
@@ -8,7 +8,7 @@ export class ScriptPackagesListToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'script_packages_list',
-      'List Unity packages in the project (optionally include built‑in). BEST PRACTICES: Use to discover available packages and their paths. Set includeBuiltIn=false to see only user packages. Returns package IDs, versions, and resolved paths. Embedded packages can be edited directly. Essential for understanding project dependencies.',
+      '[OFFLINE] No Unity connection required. List Unity packages in the project (optionally include built‑in). BEST PRACTICES: Use to discover available packages and their paths. Set includeBuiltIn=false to see only user packages. Returns package IDs, versions, and resolved paths. Embedded packages can be edited directly. Essential for understanding project dependencies.',
       {
         type: 'object',
         properties: {

--- a/mcp-server/src/handlers/script/ScriptReadToolHandler.js
+++ b/mcp-server/src/handlers/script/ScriptReadToolHandler.js
@@ -7,7 +7,7 @@ export class ScriptReadToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'script_read',
-      'Read a C# file with optional line range and payload limits. Files must be under Assets/ or Packages/ and have .cs extension. PRIORITY: Read minimally — locate the target with script_symbols_get and read only the signature area (~30–40 lines). For large files, always pass startLine/endLine and (optionally) maxBytes.',
+      '[OFFLINE] No Unity connection required. Read a C# file with optional line range and payload limits. Files must be under Assets/ or Packages/ and have .cs extension. PRIORITY: Read minimally — locate the target with script_symbols_get and read only the signature area (~30–40 lines). For large files, always pass startLine/endLine and (optionally) maxBytes.',
       {
         type: 'object',
         properties: {

--- a/mcp-server/src/handlers/script/ScriptRefsFindToolHandler.js
+++ b/mcp-server/src/handlers/script/ScriptRefsFindToolHandler.js
@@ -8,7 +8,7 @@ export class ScriptRefsFindToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'script_refs_find',
-      'Find code references/usages using the bundled C# LSP. LLM-friendly paging/summary: respects pageSize and maxBytes, caps matches per file (maxMatchesPerFile), and trims snippet text to ~400 chars. Use scope/name/kind/path to narrow results.',
+      '[OFFLINE] No Unity connection required. Find code references/usages using the bundled C# LSP. LLM-friendly paging/summary: respects pageSize and maxBytes, caps matches per file (maxMatchesPerFile), and trims snippet text to ~400 chars. Use scope/name/kind/path to narrow results.',
       {
         type: 'object',
         properties: {

--- a/mcp-server/src/handlers/script/ScriptSearchToolHandler.js
+++ b/mcp-server/src/handlers/script/ScriptSearchToolHandler.js
@@ -8,7 +8,7 @@ export class ScriptSearchToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'script_search',
-      'Search C# by substring/regex/glob with pagination and snippet context. PRIORITY: Use to locate symbols/files; avoid full contents. Use returnMode="snippets" (or "metadata") with small snippetContext (1–2). Narrow aggressively via include globs under Assets/** or Packages/** and semantic filters (namespace/container/identifier). Do NOT prefix repository folders.',
+      '[OFFLINE] No Unity connection required. Search C# by substring/regex/glob with pagination and snippet context. PRIORITY: Use to locate symbols/files; avoid full contents. Use returnMode="snippets" (or "metadata") with small snippetContext (1–2). Narrow aggressively via include globs under Assets/** or Packages/** and semantic filters (namespace/container/identifier). Do NOT prefix repository folders.',
       {
         type: 'object',
         properties: {

--- a/mcp-server/src/handlers/script/ScriptSymbolFindToolHandler.js
+++ b/mcp-server/src/handlers/script/ScriptSymbolFindToolHandler.js
@@ -6,7 +6,7 @@ export class ScriptSymbolFindToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'script_symbol_find',
-      'Find symbol definitions by name (class/method/field/property) using the bundled C# LSP. Guidance: prefer narrowing by kind and set exact=true when possible; use scope=assets|packages to avoid large outputs. Use results (container, namespace) to construct container namePath like Outer/Nested/Member for subsequent edit tools.',
+      '[OFFLINE] No Unity connection required. Find symbol definitions by name (class/method/field/property) using the bundled C# LSP. Guidance: prefer narrowing by kind and set exact=true when possible; use scope=assets|packages to avoid large outputs. Use results (container, namespace) to construct container namePath like Outer/Nested/Member for subsequent edit tools.',
       {
         type: 'object',
         properties: {

--- a/mcp-server/src/handlers/script/ScriptSymbolsGetToolHandler.js
+++ b/mcp-server/src/handlers/script/ScriptSymbolsGetToolHandler.js
@@ -8,7 +8,7 @@ export class ScriptSymbolsGetToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super(
       'script_symbols_get',
-      'FIRST STEP: Identify symbols (classes, methods, fields, properties) with spans before any edit. Path must start with Assets/ or Packages/. Use this to scope changes to a single symbol and avoid line-based edits. Returns line/column positions and container names (helpful to build container namePath like Outer/Nested/Member).',
+      '[OFFLINE] No Unity connection required. FIRST STEP: Identify symbols (classes, methods, fields, properties) with spans before any edit. Path must start with Assets/ or Packages/. Use this to scope changes to a single symbol and avoid line-based edits. Returns line/column positions and container names (helpful to build container namePath like Outer/Nested/Member).',
       {
         type: 'object',
         properties: {

--- a/mcp-server/tests/unit/core/server.test.js
+++ b/mcp-server/tests/unit/core/server.test.js
@@ -78,9 +78,8 @@ describe('Server', () => {
       });
 
       // Import and test the handler directly
-      const { SystemPingToolHandler } = await import(
-        '../../../src/handlers/system/SystemPingToolHandler.js'
-      );
+      const { SystemPingToolHandler } =
+        await import('../../../src/handlers/system/SystemPingToolHandler.js');
       const pingHandler = new SystemPingToolHandler(unityConnection);
 
       const result = await pingHandler.handle({ message: 'test' });
@@ -90,9 +89,8 @@ describe('Server', () => {
     });
 
     it('should handle gameobject_create with validation', async () => {
-      const { GameObjectCreateToolHandler } = await import(
-        '../../../src/handlers/gameobject/GameObjectCreateToolHandler.js'
-      );
+      const { GameObjectCreateToolHandler } =
+        await import('../../../src/handlers/gameobject/GameObjectCreateToolHandler.js');
       const handler = new GameObjectCreateToolHandler(unityConnection);
 
       // Test validation error
@@ -190,9 +188,8 @@ describe('Server', () => {
 
   describe('Unity connection handling', () => {
     it('should handle Unity connection errors gracefully', async () => {
-      const { SystemPingToolHandler } = await import(
-        '../../../src/handlers/system/SystemPingToolHandler.js'
-      );
+      const { SystemPingToolHandler } =
+        await import('../../../src/handlers/system/SystemPingToolHandler.js');
       const handler = new SystemPingToolHandler(unityConnection);
 
       unityConnection.sendCommand.mock.mockImplementation(async () => {
@@ -201,18 +198,21 @@ describe('Server', () => {
 
       const result = await handler.handle({});
 
-      assert.equal(result.status, 'error');
-      assert.equal(result.error, 'Unity not responding');
-      assert.equal(result.code, 'TOOL_ERROR');
+      // SystemPingToolHandler now catches errors internally and returns
+      // success with offline tools information
+      assert.equal(result.status, 'success');
+      assert.equal(result.result.success, false);
+      assert.equal(result.result.error, 'unity_connection_failed');
+      assert.ok(Array.isArray(result.result.offlineToolsAvailable));
+      assert.ok(result.result.hint);
     });
 
     it('should connect to Unity if not connected', async () => {
       unityConnection.isConnected.mock.mockImplementation(() => false);
       unityConnection.connect = mock.fn(async () => {});
 
-      const { SystemPingToolHandler } = await import(
-        '../../../src/handlers/system/SystemPingToolHandler.js'
-      );
+      const { SystemPingToolHandler } =
+        await import('../../../src/handlers/system/SystemPingToolHandler.js');
       const handler = new SystemPingToolHandler(unityConnection);
 
       unityConnection.sendCommand.mock.mockImplementation(async () => ({

--- a/mcp-server/tests/unit/handlers/system/SystemPingToolHandler.test.js
+++ b/mcp-server/tests/unit/handlers/system/SystemPingToolHandler.test.js
@@ -1,7 +1,8 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { SystemPingToolHandler } from '../../../../src/handlers/system/SystemPingToolHandler.js';
-import { createMockUnityConnection } from '../../../utils/test-helpers.js';
+import { createMockUnityConnection, MockUnityConnection } from '../../../utils/test-helpers.js';
+import { OFFLINE_TOOLS, OFFLINE_TOOLS_HINT } from '../../../../src/constants/offlineTools.js';
 
 describe('SystemPingToolHandler', () => {
   let handler;
@@ -21,6 +22,68 @@ describe('SystemPingToolHandler', () => {
   describe('SPEC compliance', () => {
     it('should test connection to Unity Editor', () => {
       assert.equal(handler.name, 'system_ping');
+    });
+  });
+
+  describe('connection failure handling', () => {
+    it('should return offlineToolsAvailable when connection fails', async () => {
+      // Create a mock connection that fails to connect
+      const failingConnection = new MockUnityConnection({ shouldFail: true });
+      const failHandler = new SystemPingToolHandler(failingConnection);
+
+      const result = await failHandler.execute({});
+
+      assert.equal(result.success, false);
+      assert.ok(
+        Array.isArray(result.offlineToolsAvailable),
+        'offlineToolsAvailable should be an array'
+      );
+      assert.ok(
+        result.offlineToolsAvailable.length > 0,
+        'offlineToolsAvailable should not be empty'
+      );
+    });
+
+    it('should return hint message when connection fails', async () => {
+      const failingConnection = new MockUnityConnection({ shouldFail: true });
+      const failHandler = new SystemPingToolHandler(failingConnection);
+
+      const result = await failHandler.execute({});
+
+      assert.equal(result.success, false);
+      assert.ok(result.hint, 'hint should be present');
+      assert.ok(typeof result.hint === 'string', 'hint should be a string');
+      assert.ok(result.hint.length > 0, 'hint should not be empty');
+    });
+
+    it('should include all 9 offline tools in the list', async () => {
+      const failingConnection = new MockUnityConnection({ shouldFail: true });
+      const failHandler = new SystemPingToolHandler(failingConnection);
+
+      const result = await failHandler.execute({});
+
+      assert.equal(result.success, false);
+      assert.deepEqual(result.offlineToolsAvailable, OFFLINE_TOOLS);
+      assert.equal(result.offlineToolsAvailable.length, 9);
+    });
+
+    it('should return error code unity_connection_failed', async () => {
+      const failingConnection = new MockUnityConnection({ shouldFail: true });
+      const failHandler = new SystemPingToolHandler(failingConnection);
+
+      const result = await failHandler.execute({});
+
+      assert.equal(result.success, false);
+      assert.equal(result.error, 'unity_connection_failed');
+    });
+
+    it('should use OFFLINE_TOOLS_HINT constant for hint message', async () => {
+      const failingConnection = new MockUnityConnection({ shouldFail: true });
+      const failHandler = new SystemPingToolHandler(failingConnection);
+
+      const result = await failHandler.execute({});
+
+      assert.equal(result.hint, OFFLINE_TOOLS_HINT);
     });
   });
 });


### PR DESCRIPTION
## Summary

Unity接続失敗時に、LLMがコードインデックス機能も利用不可と誤認識する問題を修正。

### 変更内容

- 9つのオフラインツールのdescriptionに`[OFFLINE] No Unity connection required.`タグを追加
- `system_ping`失敗時に利用可能なオフラインツールリストを返すよう改善
- 定数ファイル`offlineTools.js`を新規作成

### 対象ツール（Unity接続不要）

| ツール | 機能 |
|--------|------|
| `code_index_status` | インデックス状態確認 |
| `code_index_build` | インデックス構築 |
| `code_index_update` | インデックス更新 |
| `script_symbols_get` | ファイル内シンボル取得 |
| `script_symbol_find` | シンボル検索 |
| `script_refs_find` | 参照検索 |
| `script_read` | C#ファイル読み取り |
| `script_search` | C#コード検索 |
| `script_packages_list` | パッケージ一覧 |

### ping失敗時のレスポンス例

```json
{
  "success": false,
  "error": "unity_connection_failed",
  "offlineToolsAvailable": ["code_index_status", ...],
  "hint": "Code index and script analysis tools work without Unity connection..."
}
```

## Test plan

- [x] SystemPingToolHandler接続失敗テスト（5ケース追加）
- [x] server.test.js既存テストの期待値更新
- [x] 全78テスト合格確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)