### PR TITLE
fix: 起動時のtools/listを高速化

### DIFF
--- a/mcp-server/src/core/toolManifest.json
+++ b/mcp-server/src/core/toolManifest.json
@@ -1,0 +1,4436 @@
+[
+  {
+    "name": "addressables_analyze",
+    "description": "Analyze Unity Addressables for duplicates, dependencies, and unused assets",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "analyze_duplicates",
+            "analyze_dependencies",
+            "analyze_unused"
+          ],
+          "description": "The Addressables analysis operation to perform"
+        },
+        "assetPath": {
+          "type": "string",
+          "pattern": "^Assets/.+",
+          "description": "Asset path to analyze dependencies (required for analyze_dependencies)"
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 20,
+          "description": "Number of results per page (for analyze_duplicates, analyze_unused)"
+        },
+        "offset": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Offset for pagination"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "addressables_build",
+    "description": "Build Unity Addressables content or clean build cache",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "build",
+            "clean_build"
+          ],
+          "description": "The Addressables build operation to perform"
+        },
+        "buildTarget": {
+          "type": "string",
+          "enum": [
+            "StandaloneWindows64",
+            "StandaloneWindows",
+            "StandaloneLinux64",
+            "StandaloneOSX",
+            "iOS",
+            "Android",
+            "WebGL"
+          ],
+          "description": "Optional build target platform (for build action)"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "addressables_manage",
+    "description": "Manage Unity Addressables assets and groups - add, remove, organize entries and groups",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "add_entry",
+            "remove_entry",
+            "set_address",
+            "add_label",
+            "remove_label",
+            "list_entries",
+            "list_groups",
+            "create_group",
+            "remove_group",
+            "move_entry"
+          ],
+          "description": "The Addressables management operation to perform"
+        },
+        "assetPath": {
+          "type": "string",
+          "pattern": "^Assets/.+",
+          "description": "Asset path starting with Assets/ (required for most actions)"
+        },
+        "address": {
+          "type": "string",
+          "description": "Addressable name/address (required for add_entry)"
+        },
+        "groupName": {
+          "type": "string",
+          "description": "Group name (required for add_entry, create_group, remove_group)"
+        },
+        "targetGroupName": {
+          "type": "string",
+          "description": "Target group name for move_entry"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label name for add_label/remove_label"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Labels to add (optional for add_entry)"
+        },
+        "newAddress": {
+          "type": "string",
+          "description": "New address name for set_address"
+        },
+        "pageSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 20,
+          "description": "Number of results per page (for list_entries)"
+        },
+        "offset": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Offset for pagination (for list_entries)"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "analysis_animator_runtime_info_get",
+    "description": "Get Animator runtime info (IK, root motion, performance) — Play mode only.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectName": {
+          "type": "string",
+          "description": "Name of the GameObject with the Animator component"
+        },
+        "includeIK": {
+          "type": "boolean",
+          "description": "Include IK (Inverse Kinematics) information. Default: true",
+          "default": true
+        },
+        "includeRootMotion": {
+          "type": "boolean",
+          "description": "Include root motion information. Default: true",
+          "default": true
+        },
+        "includeBehaviours": {
+          "type": "boolean",
+          "description": "Include state machine behaviours. Default: false",
+          "default": false
+        }
+      },
+      "required": [
+        "gameObjectName"
+      ]
+    }
+  },
+  {
+    "name": "analysis_animator_state_get",
+    "description": "Get Animator state: layers, transitions, and parameter values for a GameObject.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectName": {
+          "type": "string",
+          "description": "Name of the GameObject with the Animator component"
+        },
+        "includeParameters": {
+          "type": "boolean",
+          "description": "Include all animator parameters and their current values. Default: true",
+          "default": true
+        },
+        "includeStates": {
+          "type": "boolean",
+          "description": "Include current state information for each layer. Default: true",
+          "default": true
+        },
+        "includeTransitions": {
+          "type": "boolean",
+          "description": "Include active transition information. Default: true",
+          "default": true
+        },
+        "includeClips": {
+          "type": "boolean",
+          "description": "Include animation clip information. Default: false",
+          "default": false
+        },
+        "layerIndex": {
+          "type": "number",
+          "description": "Specific layer index to query (-1 for all layers). Default: -1",
+          "default": -1
+        }
+      },
+      "required": [
+        "gameObjectName"
+      ]
+    }
+  },
+  {
+    "name": "analysis_component_find",
+    "description": "Find GameObjects that have a specific component type (scene/prefabs/all).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "componentType": {
+          "type": "string",
+          "description": "Component type to search for (e.g., \"Light\", \"Collider\", \"AudioSource\")"
+        },
+        "includeInactive": {
+          "type": "boolean",
+          "description": "Include inactive GameObjects. Default: true"
+        },
+        "searchScope": {
+          "type": "string",
+          "enum": [
+            "scene",
+            "prefabs",
+            "all"
+          ],
+          "description": "Where to search: current scene, prefabs, or all. Default: \"scene\""
+        },
+        "matchExactType": {
+          "type": "boolean",
+          "description": "Match exact type only (not derived types). Default: true"
+        }
+      },
+      "required": [
+        "componentType"
+      ]
+    }
+  },
+  {
+    "name": "analysis_component_values_get",
+    "description": "Get properties/values from a component on a GameObject (scene or prefab mode).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectName": {
+          "type": "string",
+          "description": "Name of the GameObject"
+        },
+        "componentType": {
+          "type": "string",
+          "description": "Type of component (e.g., \"Light\", \"Camera\", \"Rigidbody\")"
+        },
+        "componentIndex": {
+          "type": "number",
+          "description": "Index if multiple components of same type. Default: 0"
+        },
+        "includePrivateFields": {
+          "type": "boolean",
+          "description": "Include non-public fields. Default: false"
+        },
+        "includeInherited": {
+          "type": "boolean",
+          "description": "Include inherited properties. Default: true"
+        }
+      },
+      "required": [
+        "gameObjectName",
+        "componentType"
+      ]
+    }
+  },
+  {
+    "name": "analysis_gameobject_details_get",
+    "description": "Get details for a GameObject by name or path (children/components/materials).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectName": {
+          "type": "string",
+          "description": "Name of the GameObject to inspect"
+        },
+        "path": {
+          "type": "string",
+          "description": "Full hierarchy path to the GameObject (use either name or path)"
+        },
+        "includeChildren": {
+          "type": "boolean",
+          "description": "Include full hierarchy details. Default: false"
+        },
+        "includeComponents": {
+          "type": "boolean",
+          "description": "Include all component details. Default: true"
+        },
+        "includeMaterials": {
+          "type": "boolean",
+          "description": "Include material information. Default: false"
+        },
+        "maxDepth": {
+          "type": "number",
+          "description": "Maximum depth for child traversal. Default: 3, Range: 0-10"
+        }
+      },
+      "required": [
+        "gameObjectName"
+      ]
+    }
+  },
+  {
+    "name": "analysis_object_references_get",
+    "description": "Find references to and from a GameObject (hierarchy/assets/prefabs).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectName": {
+          "type": "string",
+          "description": "Name of the GameObject to analyze references for"
+        },
+        "includeAssetReferences": {
+          "type": "boolean",
+          "description": "Include references to assets (materials, meshes, etc). Default: true"
+        },
+        "includeHierarchyReferences": {
+          "type": "boolean",
+          "description": "Include parent/child hierarchy references. Default: true"
+        },
+        "searchInPrefabs": {
+          "type": "boolean",
+          "description": "Also search for references in prefab assets. Default: false"
+        }
+      },
+      "required": [
+        "gameObjectName"
+      ]
+    }
+  },
+  {
+    "name": "analysis_scene_contents_analyze",
+    "description": "Analyze current scene: object counts, types, prefabs, and memory stats.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "includeInactive": {
+          "type": "boolean",
+          "description": "Include inactive objects in analysis. Default: true"
+        },
+        "groupByType": {
+          "type": "boolean",
+          "description": "Group results by component types. Default: true"
+        },
+        "includePrefabInfo": {
+          "type": "boolean",
+          "description": "Include prefab connection info. Default: true"
+        },
+        "includeMemoryInfo": {
+          "type": "boolean",
+          "description": "Include memory usage estimates. Default: false"
+        }
+      }
+    }
+  },
+  {
+    "name": "asset_database_manage",
+    "description": "Manage Unity Asset Database operations (find, info, create folders, move, copy, delete, refresh). NOTE: The \"refresh\" action may take 5-120+ seconds for large projects as Unity needs to scan all assets, reimport changed files, and compile scripts. Please wait for the operation to complete.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "find_assets",
+            "get_asset_info",
+            "create_folder",
+            "delete_asset",
+            "move_asset",
+            "copy_asset",
+            "refresh",
+            "save"
+          ],
+          "description": "The action to perform"
+        },
+        "filter": {
+          "type": "string",
+          "description": "Search filter for find_assets (e.g., \"t:Texture2D\", \"l:UI\")"
+        },
+        "searchInFolders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Folders to search in for find_assets (optional)"
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset (must start with \"Assets/\")"
+        },
+        "folderPath": {
+          "type": "string",
+          "description": "Path for folder creation (must start with \"Assets/\")"
+        },
+        "fromPath": {
+          "type": "string",
+          "description": "Source path for move/copy operations"
+        },
+        "toPath": {
+          "type": "string",
+          "description": "Destination path for move/copy operations"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "asset_dependency_analyze",
+    "description": "Analyze Unity asset dependencies (get dependencies, dependents, circular deps, unused assets, size impact)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "get_dependencies",
+            "get_dependents",
+            "analyze_circular",
+            "find_unused",
+            "analyze_size_impact",
+            "validate_references"
+          ],
+          "description": "The analysis action to perform"
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset (required for specific asset analysis)"
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "Whether to analyze dependencies recursively (for get_dependencies)"
+        },
+        "includeBuiltIn": {
+          "type": "boolean",
+          "description": "Whether to include built-in assets in analysis (for find_unused)"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "asset_import_settings_manage",
+    "description": "Manage Unity asset import settings (get, modify, apply presets, reimport)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "get",
+            "modify",
+            "apply_preset",
+            "reimport"
+          ],
+          "description": "The action to perform"
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset (must start with \"Assets/\")"
+        },
+        "settings": {
+          "type": "object",
+          "description": "Import settings to apply (required for modify action)"
+        },
+        "preset": {
+          "type": "string",
+          "description": "Name of the preset to apply (required for apply_preset action)"
+        }
+      },
+      "required": [
+        "action",
+        "assetPath"
+      ]
+    }
+  },
+  {
+    "name": "asset_material_create",
+    "description": "Create a material asset with a shader and property overrides (optional copyFrom).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "materialPath": {
+          "type": "string",
+          "description": "Asset path for the material. Must start with Assets/ and end with .mat."
+        },
+        "shader": {
+          "type": "string",
+          "description": "Shader to use (e.g., Standard, Unlit/Color, Universal Render Pipeline/Lit)."
+        },
+        "properties": {
+          "type": "object",
+          "description": "Material property overrides (e.g., {\"_Color\":[1,0,0,1], \"_Metallic\":0.5})."
+        },
+        "copyFrom": {
+          "type": "string",
+          "description": "Optional: path to an existing material to clone before applying overrides."
+        },
+        "overwrite": {
+          "type": "boolean",
+          "description": "If true, overwrite existing material at the path."
+        }
+      },
+      "required": [
+        "materialPath"
+      ]
+    }
+  },
+  {
+    "name": "asset_material_modify",
+    "description": "Modify a material by updating property values and/or changing the shader.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "materialPath": {
+          "type": "string",
+          "description": "Asset path to the material. Must start with Assets/ and end with .mat."
+        },
+        "properties": {
+          "type": "object",
+          "description": "Property updates (e.g., {\"_Color\":[1,0,0,1], \"_Metallic\":0.5})."
+        },
+        "shader": {
+          "type": "string",
+          "description": "Optional: change the shader (e.g., Standard, Unlit/Color)."
+        }
+      },
+      "required": [
+        "materialPath",
+        "properties"
+      ]
+    }
+  },
+  {
+    "name": "asset_prefab_create",
+    "description": "Create a prefab from a GameObject path or create an empty prefab at a target asset path.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectPath": {
+          "type": "string",
+          "description": "Scene path to convert (e.g., \"/Root/Player\"). Mutually exclusive with createFromTemplate."
+        },
+        "prefabPath": {
+          "type": "string",
+          "description": "Asset path for the prefab. Must start with Assets/ and end with .prefab."
+        },
+        "createFromTemplate": {
+          "type": "boolean",
+          "description": "If true, create an empty prefab (no source GameObject) (default: false)."
+        },
+        "overwrite": {
+          "type": "boolean",
+          "description": "If true, overwrite existing prefab at the destination path (default: false)."
+        }
+      },
+      "required": [
+        "prefabPath"
+      ]
+    }
+  },
+  {
+    "name": "asset_prefab_exit_mode",
+    "description": "Exit prefab mode and return to the main scene",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "saveChanges": {
+          "type": "boolean",
+          "description": "Save changes before exiting (default: true)"
+        }
+      }
+    }
+  },
+  {
+    "name": "asset_prefab_instantiate",
+    "description": "Instantiate a prefab in the scene with optional transform, parent, and name override.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "prefabPath": {
+          "type": "string",
+          "description": "Asset path to the prefab. Must start with Assets/ and end with .prefab."
+        },
+        "position": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "description": "World position for the instance (requires x,y,z)."
+        },
+        "rotation": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "description": "Euler rotation for the instance (x,y,z)."
+        },
+        "parent": {
+          "type": "string",
+          "description": "Parent GameObject scene path (optional)."
+        },
+        "name": {
+          "type": "string",
+          "description": "Override name for the instantiated object."
+        }
+      },
+      "required": [
+        "prefabPath"
+      ]
+    }
+  },
+  {
+    "name": "asset_prefab_modify",
+    "description": "Modify an existing prefab by applying property changes (optionally to instances).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "prefabPath": {
+          "type": "string",
+          "description": "Asset path to the prefab. Must start with Assets/ and end with .prefab."
+        },
+        "modifications": {
+          "type": "object",
+          "description": "Key/value object of properties to modify on the prefab."
+        },
+        "applyToInstances": {
+          "type": "boolean",
+          "description": "If true, also apply to existing scene instances (default: true)."
+        }
+      },
+      "required": [
+        "prefabPath",
+        "modifications"
+      ]
+    }
+  },
+  {
+    "name": "asset_prefab_open",
+    "description": "Open a prefab asset in prefab mode for editing. Once in prefab mode, use component tools (list_components, add_component, etc.) to inspect and modify components.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "prefabPath": {
+          "type": "string",
+          "description": "Asset path to the prefab (must start with Assets/ and end with .prefab)"
+        },
+        "focusObject": {
+          "type": "string",
+          "description": "Optional path to object within prefab to focus on (relative to prefab root)"
+        },
+        "isolateObject": {
+          "type": "boolean",
+          "description": "Isolate the focused object in the hierarchy (default: false)"
+        }
+      },
+      "required": [
+        "prefabPath"
+      ]
+    }
+  },
+  {
+    "name": "asset_prefab_save",
+    "description": "Save current prefab changes in prefab mode or save a GameObject as prefab override",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectPath": {
+          "type": "string",
+          "description": "Path to GameObject to save as prefab override (optional - if not provided, saves current prefab in prefab mode)"
+        },
+        "includeChildren": {
+          "type": "boolean",
+          "description": "Include child object overrides when saving (default: true)"
+        }
+      }
+    }
+  },
+  {
+    "name": "code_index_build",
+    "description": "[OFFLINE] No Unity connection required. Build (or rebuild) the persistent SQLite symbol index by scanning document symbols via the C# LSP. Returns immediately with jobId for background execution. Check progress with code_index_status. Stores DB under .unity/cache/code-index/code-index.db.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "throttleMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Optional delay in milliseconds after processing each file (testing/debugging)."
+        },
+        "retry": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 5,
+          "description": "Number of retries for LSP requests (default: 2)."
+        }
+      }
+    }
+  },
+  {
+    "name": "code_index_status",
+    "description": "[OFFLINE] No Unity connection required. Report code index status and readiness for symbol/search operations. BEST PRACTICES: Check before heavy symbol operations. Shows total files indexed and coverage percentage. If coverage is low, some symbol operations may be incomplete. Index is automatically built on first use. No parameters needed - lightweight status check.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "code_index_update",
+    "description": "[OFFLINE] No Unity connection required. Refresh code index entries for specific C# files. Use this after modifying files so script editing tools see the latest symbols.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "List of absolute or project-relative C# file paths to re-index."
+        },
+        "retry": {
+          "type": "number",
+          "description": "Number of retries when requesting document symbols (default 1)."
+        },
+        "concurrency": {
+          "type": "number",
+          "description": "Maximum number of concurrent LSP requests. Default 4."
+        }
+      },
+      "required": [
+        "paths"
+      ]
+    }
+  },
+  {
+    "name": "compilation_get_state",
+    "description": "Get current Unity compilation state, errors, and warnings with enhanced detection",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "includeMessages": {
+          "type": "boolean",
+          "description": "Include detailed compilation messages. Unity default: false. Set to true for debugging compilation issues"
+        },
+        "maxMessages": {
+          "type": "number",
+          "description": "Maximum number of messages to return (default: 50)"
+        }
+      }
+    }
+  },
+  {
+    "name": "component_add",
+    "description": "Add a component to a GameObject (scene or prefab mode) with optional initial properties.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectPath": {
+          "type": "string",
+          "description": "Scene path to the GameObject (e.g., \"/Player\" or \"/Canvas/Button\")."
+        },
+        "componentType": {
+          "type": "string",
+          "description": "Type of component to add (e.g., \"Rigidbody\", \"BoxCollider\", \"Light\")"
+        },
+        "properties": {
+          "type": "object",
+          "description": "Initial property values to set on the new component.",
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "gameObjectPath",
+        "componentType"
+      ]
+    }
+  },
+  {
+    "name": "component_field_set",
+    "description": "Update a serialized field on a component (scene hierarchy, prefab stage, or prefab asset).",
+    "inputSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "scene",
+            "prefabStage",
+            "prefabAsset"
+          ],
+          "description": "Explicit scope for the operation. Use auto (default) to detect automatically."
+        },
+        "gameObjectPath": {
+          "type": "string",
+          "description": "Absolute path to the target GameObject (e.g., \"/Player/Weapon\"). Required unless prefabAssetPath is provided."
+        },
+        "prefabAssetPath": {
+          "type": "string",
+          "description": "Asset path to the prefab to edit (e.g., \"Assets/Prefabs/Enemy.prefab\")."
+        },
+        "prefabObjectPath": {
+          "type": "string",
+          "description": "Path to the object inside the prefab asset (defaults to the prefab root when omitted)."
+        },
+        "componentType": {
+          "type": "string",
+          "description": "Component type to edit (short name or fully qualified name)."
+        },
+        "componentIndex": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Component index when multiple components of the same type are present. Default: 0."
+        },
+        "fieldPath": {
+          "type": "string",
+          "description": "Serialized field path to update. Supports dot and bracket notation (e.g., \"settings.speed\", \"items[0].damage\")."
+        },
+        "value": {
+          "description": "New value for the field. Accepts JSON scalars, objects, or arrays depending on the target type."
+        },
+        "valueType": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "bool",
+            "int",
+            "long",
+            "float",
+            "double",
+            "string",
+            "color",
+            "vector2",
+            "vector3",
+            "vector4",
+            "vector2Int",
+            "vector3Int",
+            "quaternion",
+            "rect",
+            "rectInt",
+            "bounds",
+            "boundsInt",
+            "enum",
+            "objectReference",
+            "array",
+            "json",
+            "null"
+          ],
+          "description": "Type hint for the value. Defaults to auto detection."
+        },
+        "enumValue": {
+          "type": "string",
+          "description": "Enum member name when setting enum fields (optional when value is already a string)."
+        },
+        "objectReference": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assetPath": {
+              "type": "string",
+              "description": "AssetDatabase path to load as an object reference."
+            },
+            "guid": {
+              "type": "string",
+              "description": "GUID of the asset to reference."
+            }
+          },
+          "description": "Explicit object reference payload. Provide assetPath or guid when setting object references."
+        },
+        "runtime": {
+          "type": "boolean",
+          "description": "Allow updates while Unity is in Play Mode (default: false)."
+        },
+        "dryRun": {
+          "type": "boolean",
+          "description": "Validate target resolution and preview the change without applying it."
+        },
+        "applyPrefabChanges": {
+          "type": "boolean",
+          "description": "When editing prefab assets, save the modified prefab asset. Defaults to true."
+        },
+        "createUndo": {
+          "type": "boolean",
+          "description": "Record an undo entry when modifying scene objects. Defaults to true."
+        },
+        "markSceneDirty": {
+          "type": "boolean",
+          "description": "Mark the owning scene dirty when modifying scene objects. Defaults to true."
+        }
+      },
+      "required": [
+        "componentType",
+        "fieldPath"
+      ]
+    }
+  },
+  {
+    "name": "component_get_types",
+    "description": "Get available component types in Unity",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Filter by category (e.g., \"Physics\", \"Rendering\", \"UI\")"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search for component types by name"
+        },
+        "onlyAddable": {
+          "type": "boolean",
+          "description": "Return only components that can be added to GameObjects (default: false)"
+        }
+      }
+    }
+  },
+  {
+    "name": "component_list",
+    "description": "List all components on a GameObject in Unity (works in both scene and prefab mode)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectPath": {
+          "type": "string",
+          "description": "Path to the GameObject (e.g., \"/Player\" or \"/Canvas/Button\")"
+        },
+        "includeInherited": {
+          "type": "boolean",
+          "description": "Include inherited base component types (default: false)"
+        }
+      },
+      "required": [
+        "gameObjectPath"
+      ]
+    }
+  },
+  {
+    "name": "component_modify",
+    "description": "Modify properties of a component on a GameObject in Unity (works in both scene and prefab mode)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectPath": {
+          "type": "string",
+          "description": "Path to the GameObject (e.g., \"/Player\" or \"/Canvas/Button\")"
+        },
+        "componentType": {
+          "type": "string",
+          "description": "Type of component to modify (e.g., \"Rigidbody\", \"Light\")"
+        },
+        "componentIndex": {
+          "type": "number",
+          "description": "Index of component if multiple of same type exist (default: 0)"
+        },
+        "properties": {
+          "type": "object",
+          "description": "Properties to modify with their new values",
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "gameObjectPath",
+        "componentType",
+        "properties"
+      ]
+    }
+  },
+  {
+    "name": "component_remove",
+    "description": "Remove a component from a GameObject (scene or prefab mode) by type/index.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "gameObjectPath": {
+          "type": "string",
+          "description": "Path to the GameObject (e.g., \"/Player\" or \"/Canvas/Button\")"
+        },
+        "componentType": {
+          "type": "string",
+          "description": "Type of component to remove (e.g., \"Rigidbody\", \"BoxCollider\")"
+        },
+        "componentIndex": {
+          "type": "number",
+          "description": "Index of component if multiple of same type exist (default: 0)"
+        }
+      },
+      "required": [
+        "gameObjectPath",
+        "componentType"
+      ]
+    }
+  },
+  {
+    "name": "console_clear",
+    "description": "Clear Console logs (optionally set auto-clear and preserve levels).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "clearOnPlay": {
+          "type": "boolean",
+          "description": "Clear console when entering play mode. Unity default: false. Set to true for cleaner testing sessions"
+        },
+        "clearOnRecompile": {
+          "type": "boolean",
+          "description": "Clear console on script recompilation. Unity default: false. Set to true to focus on current compilation errors"
+        },
+        "clearOnBuild": {
+          "type": "boolean",
+          "description": "Clear console when building. Unity default: false. Set to true for clean build logs"
+        },
+        "preserveWarnings": {
+          "type": "boolean",
+          "description": "Preserve warning messages when clearing (default: false)"
+        },
+        "preserveErrors": {
+          "type": "boolean",
+          "description": "Preserve error messages when clearing (default: false)"
+        }
+      }
+    }
+  },
+  {
+    "name": "console_read",
+    "description": "Read Console logs with filters (type/text/time), formatting, sort, and grouping.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "raw": {
+          "type": "boolean",
+          "description": "When true, do not expand/validate logTypes and pass them directly to Unity. Use with caution."
+        },
+        "count": {
+          "type": "number",
+          "description": "Number of logs to retrieve (1-1000, default: 100)",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "logTypes": {
+          "type": "array",
+          "description": "Filter by log types. Allowed: Log, Warning, Error. Error expands to include Exception/Assert internally. Default: all three.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Log",
+              "Warning",
+              "Error"
+            ]
+          }
+        },
+        "filterText": {
+          "type": "string",
+          "description": "Filter logs containing this text (case-insensitive)"
+        },
+        "includeStackTrace": {
+          "type": "boolean",
+          "description": "Include stack traces in results (default: false). Set to true only when debugging to reduce response size.",
+          "default": false
+        },
+        "format": {
+          "type": "string",
+          "description": "Output format for logs. Unity default: compact. RECOMMENDED: compact for general use, detailed for debugging",
+          "enum": [
+            "detailed",
+            "compact",
+            "json",
+            "plain"
+          ]
+        },
+        "sinceTimestamp": {
+          "type": "string",
+          "description": "Only return logs after this timestamp (ISO 8601)"
+        },
+        "untilTimestamp": {
+          "type": "string",
+          "description": "Only return logs before this timestamp (ISO 8601)"
+        },
+        "sortOrder": {
+          "type": "string",
+          "description": "Sort order for logs (default: newest)",
+          "enum": [
+            "newest",
+            "oldest"
+          ]
+        },
+        "groupBy": {
+          "type": "string",
+          "description": "Group logs by criteria (default: none)",
+          "enum": [
+            "none",
+            "type",
+            "file",
+            "time"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "editor_layers_manage",
+    "description": "Manage project layers: add/remove/list and convert (by name/index).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "add",
+            "remove",
+            "get",
+            "get_by_name",
+            "get_by_index"
+          ],
+          "description": "Operation: add, remove, get, get_by_name, or get_by_index."
+        },
+        "layerName": {
+          "type": "string",
+          "description": "Layer name (required for add/remove/get_by_name). Letters/numbers/space/_ only."
+        },
+        "layerIndex": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 31,
+          "description": "Layer index (0-31). Required for get_by_index."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "editor_quit",
+    "description": "Quit Unity Editor",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "editor_selection_manage",
+    "description": "Manage editor selection: get/set/clear and optionally include details.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "get",
+            "set",
+            "clear",
+            "get_details"
+          ],
+          "description": "Operation: get, set, clear, or get_details."
+        },
+        "objectPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "GameObject paths for set (e.g., [\"/Main Camera\", \"/Player\"]). Must start with /."
+        },
+        "includeDetails": {
+          "type": "boolean",
+          "description": "If true, return detailed info with get/get_details."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "editor_tags_manage",
+    "description": "Manage project tags: add/remove/list with validation for reserved names.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "add",
+            "remove",
+            "get"
+          ],
+          "description": "Operation: add, remove, or get."
+        },
+        "tagName": {
+          "type": "string",
+          "description": "Tag name (required for add/remove). Alphanumeric/underscore only."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "editor_tools_manage",
+    "description": "Manage editor tools/plugins: list, activate/deactivate, refresh cache.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "get",
+            "activate",
+            "deactivate",
+            "refresh"
+          ],
+          "description": "Operation: get, activate, deactivate, or refresh."
+        },
+        "toolName": {
+          "type": "string",
+          "description": "Tool name (required for activate/deactivate)."
+        },
+        "category": {
+          "type": "string",
+          "description": "Optional: filter list by category."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "editor_windows_manage",
+    "description": "Manage editor windows: list/focus/get_state including hidden windows.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "get",
+            "focus",
+            "get_state"
+          ],
+          "description": "Operation: get (list), focus, or get_state."
+        },
+        "windowType": {
+          "type": "string",
+          "description": "Window type (e.g., SceneView, GameView, InspectorWindow). Required for focus/get_state."
+        },
+        "includeHidden": {
+          "type": "boolean",
+          "description": "If true, includes hidden/minimized windows for get."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "gameobject_create",
+    "description": "Create a GameObject in Unity scene",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the GameObject (default: \"GameObject\")"
+        },
+        "primitiveType": {
+          "type": "string",
+          "description": "Type of primitive to create",
+          "enum": [
+            "cube",
+            "sphere",
+            "cylinder",
+            "capsule",
+            "plane",
+            "quad"
+          ]
+        },
+        "position": {
+          "type": "object",
+          "description": "World position",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          }
+        },
+        "rotation": {
+          "type": "object",
+          "description": "Rotation in Euler angles",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          }
+        },
+        "scale": {
+          "type": "object",
+          "description": "Local scale",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          }
+        },
+        "parentPath": {
+          "type": "string",
+          "description": "Path to parent GameObject (e.g., \"/Parent/Child\")"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Tag to assign to the GameObject"
+        },
+        "layer": {
+          "type": "number",
+          "description": "Layer index (0-31)",
+          "minimum": 0,
+          "maximum": 31
+        }
+      }
+    }
+  },
+  {
+    "name": "gameobject_delete",
+    "description": "Delete GameObject(s) by path or paths (optionally include children).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to a single GameObject to delete"
+        },
+        "paths": {
+          "type": "array",
+          "description": "Array of paths to multiple GameObjects to delete",
+          "items": {
+            "type": "string"
+          }
+        },
+        "includeChildren": {
+          "type": "boolean",
+          "description": "Whether to delete children (default: true)"
+        }
+      }
+    }
+  },
+  {
+    "name": "gameobject_find",
+    "description": "Find GameObjects by name, tag, or layer with optional exact matching.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name to search for"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Tag to search for"
+        },
+        "layer": {
+          "type": "number",
+          "description": "Layer index to search for (0-31)",
+          "minimum": 0,
+          "maximum": 31
+        },
+        "exactMatch": {
+          "type": "boolean",
+          "description": "Whether to match name exactly (default: false)"
+        }
+      }
+    }
+  },
+  {
+    "name": "gameobject_get_hierarchy",
+    "description": "Get scene hierarchy. For large scenes, prefer nameOnly=true. With nameOnly, use maxObjects ~100–500; when requesting details, keep maxObjects ~10–50 to conserve tokens. Only enable includeComponents/includeTransform when necessary.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "rootPath": {
+          "type": "string",
+          "description": "Path to GameObject whose children will be the root of the returned hierarchy (e.g., \"/Team_0\" returns Team_0's children). If not specified, returns scene root objects."
+        },
+        "includeInactive": {
+          "type": "boolean",
+          "description": "Include inactive GameObjects (default: true)"
+        },
+        "maxDepth": {
+          "type": "number",
+          "description": "Maximum depth to traverse from the root. 0=immediate children only (default), 1=children+grandchildren, 2=children+grandchildren+great-grandchildren, etc. (-1 for unlimited)",
+          "minimum": -1
+        },
+        "includeComponents": {
+          "type": "boolean",
+          "description": "Include component information (default: false). WARNING: Significantly increases response size - use with small maxObjects values."
+        },
+        "includeTransform": {
+          "type": "boolean",
+          "description": "Include transform information (default: false). WARNING: Increases response size - use with small maxObjects values."
+        },
+        "includeTags": {
+          "type": "boolean",
+          "description": "Include tag information (default: false)"
+        },
+        "includeLayers": {
+          "type": "boolean",
+          "description": "Include layer information (default: false)"
+        },
+        "nameOnly": {
+          "type": "boolean",
+          "description": "Return only names and paths for minimal data size (default: false). RECOMMENDED for large hierarchies to reduce token usage."
+        },
+        "maxObjects": {
+          "type": "number",
+          "description": "Maximum number of objects to include in response. Unity default: 100 (-1 for unlimited). RECOMMENDED: 10-50 for detailed info, 100-500 for nameOnly mode to avoid MCP token limits",
+          "minimum": -1
+        }
+      }
+    }
+  },
+  {
+    "name": "gameobject_modify",
+    "description": "Modify GameObject properties (transform/name/parent/active/tag/layer).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the GameObject to modify (required)"
+        },
+        "name": {
+          "type": "string",
+          "description": "New name for the GameObject"
+        },
+        "position": {
+          "type": "object",
+          "description": "New world position",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          }
+        },
+        "rotation": {
+          "type": "object",
+          "description": "New rotation in Euler angles",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          }
+        },
+        "scale": {
+          "type": "object",
+          "description": "New local scale",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          }
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Set active state"
+        },
+        "parentPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to new parent GameObject (null to unparent)"
+        },
+        "tag": {
+          "type": "string",
+          "description": "New tag"
+        },
+        "layer": {
+          "type": "number",
+          "description": "New layer index (0-31)",
+          "minimum": 0,
+          "maximum": 31
+        }
+      },
+      "required": [
+        "path"
+      ]
+    }
+  },
+  {
+    "name": "input_action_add",
+    "description": "Add a new Action to an Action Map",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name of the Action Map"
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Name for the new Action"
+        },
+        "actionType": {
+          "type": "string",
+          "description": "Type of the action",
+          "enum": [
+            "Button",
+            "Value",
+            "PassThrough"
+          ],
+          "default": "Button"
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName",
+        "actionName"
+      ]
+    }
+  },
+  {
+    "name": "input_action_map_create",
+    "description": "Create a new Action Map in an Input Actions asset",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name for the new Action Map"
+        },
+        "actions": {
+          "type": "array",
+          "description": "Optional array of actions to add",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Button",
+                  "Value",
+                  "PassThrough"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName"
+      ]
+    }
+  },
+  {
+    "name": "input_action_map_remove",
+    "description": "Remove an Action Map from an Input Actions asset",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name of the Action Map to remove"
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName"
+      ]
+    }
+  },
+  {
+    "name": "input_action_remove",
+    "description": "Remove an Action from an Action Map",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name of the Action Map"
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Name of the Action to remove"
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName",
+        "actionName"
+      ]
+    }
+  },
+  {
+    "name": "input_actions_asset_analyze",
+    "description": "Analyze an Input Actions asset in detail (statistics + device usage).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "includeJsonStructure": {
+          "type": "boolean",
+          "description": "Include raw JSON structure. Default: true",
+          "default": true
+        },
+        "includeStatistics": {
+          "type": "boolean",
+          "description": "Include usage statistics. Default: true",
+          "default": true
+        }
+      },
+      "required": [
+        "assetPath"
+      ]
+    }
+  },
+  {
+    "name": "input_actions_state_get",
+    "description": "Get Input Actions state: maps, actions, bindings, devices, JSON structure.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetName": {
+          "type": "string",
+          "description": "Name of the Input Actions asset"
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "includeBindings": {
+          "type": "boolean",
+          "description": "Include binding information. Default: true",
+          "default": true
+        },
+        "includeControlSchemes": {
+          "type": "boolean",
+          "description": "Include control schemes information. Default: true",
+          "default": true
+        },
+        "includeJsonStructure": {
+          "type": "boolean",
+          "description": "Include raw JSON structure. Default: false",
+          "default": false
+        }
+      }
+    }
+  },
+  {
+    "name": "input_binding_add",
+    "description": "Add a new Binding to an Action",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name of the Action Map"
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Name of the Action"
+        },
+        "path": {
+          "type": "string",
+          "description": "Binding path (e.g., \"<Keyboard>/space\", \"<Gamepad>/buttonSouth\")"
+        },
+        "groups": {
+          "type": "string",
+          "description": "Control scheme groups (e.g., \"Keyboard&Mouse\")"
+        },
+        "interactions": {
+          "type": "string",
+          "description": "Interactions (e.g., \"press\", \"hold\")"
+        },
+        "processors": {
+          "type": "string",
+          "description": "Processors (e.g., \"scale\", \"invert\")"
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName",
+        "actionName",
+        "path"
+      ]
+    }
+  },
+  {
+    "name": "input_binding_composite_create",
+    "description": "Create a composite binding (e.g., 2D Vector for WASD movement)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name of the Action Map"
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Name of the Action"
+        },
+        "compositeType": {
+          "type": "string",
+          "description": "Type of composite",
+          "enum": [
+            "2DVector",
+            "1DAxis"
+          ],
+          "default": "2DVector"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name for the composite binding"
+        },
+        "bindings": {
+          "type": "object",
+          "description": "Binding paths for composite parts",
+          "properties": {
+            "up": {
+              "type": "string"
+            },
+            "down": {
+              "type": "string"
+            },
+            "left": {
+              "type": "string"
+            },
+            "right": {
+              "type": "string"
+            },
+            "negative": {
+              "type": "string"
+            },
+            "positive": {
+              "type": "string"
+            }
+          }
+        },
+        "groups": {
+          "type": "string",
+          "description": "Control scheme groups"
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName",
+        "actionName",
+        "bindings"
+      ]
+    }
+  },
+  {
+    "name": "input_binding_remove",
+    "description": "Remove a Binding from an Action",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name of the Action Map"
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Name of the Action"
+        },
+        "bindingIndex": {
+          "type": "number",
+          "description": "Index of the binding to remove"
+        },
+        "bindingPath": {
+          "type": "string",
+          "description": "Path of the binding to remove (alternative to bindingIndex)"
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName",
+        "actionName"
+      ]
+    }
+  },
+  {
+    "name": "input_binding_remove_all",
+    "description": "Remove all Bindings from an Action",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "mapName": {
+          "type": "string",
+          "description": "Name of the Action Map"
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Name of the Action"
+        }
+      },
+      "required": [
+        "assetPath",
+        "mapName",
+        "actionName"
+      ]
+    }
+  },
+  {
+    "name": "input_control_schemes_manage",
+    "description": "Manage Control Schemes in an Input Actions asset",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the Input Actions asset file"
+        },
+        "operation": {
+          "type": "string",
+          "description": "Operation to perform",
+          "enum": [
+            "add",
+            "remove",
+            "modify"
+          ]
+        },
+        "schemeName": {
+          "type": "string",
+          "description": "Name of the control scheme"
+        },
+        "devices": {
+          "type": "array",
+          "description": "List of device types (e.g., [\"Keyboard\", \"Mouse\", \"Gamepad\"])",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "assetPath",
+        "operation"
+      ]
+    }
+  },
+  {
+    "name": "input_gamepad",
+    "description": "Gamepad input (buttons/sticks/triggers/dpad) with batching and auto-hold.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "button",
+            "stick",
+            "trigger",
+            "dpad"
+          ],
+          "description": "The gamepad action to perform"
+        },
+        "button": {
+          "type": "string",
+          "description": "Button name (a/cross, b/circle, x/square, y/triangle, start, select, etc.)"
+        },
+        "buttonAction": {
+          "type": "string",
+          "enum": [
+            "press",
+            "release"
+          ],
+          "description": "Button action (press or release)"
+        },
+        "stick": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right"
+          ],
+          "description": "Which analog stick to control"
+        },
+        "x": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1,
+          "description": "Horizontal axis value for stick (-1 to 1)"
+        },
+        "y": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1,
+          "description": "Vertical axis value for stick (-1 to 1)"
+        },
+        "trigger": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right"
+          ],
+          "description": "Which trigger to control"
+        },
+        "value": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Trigger pressure value (0 to 1)"
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "left",
+            "right",
+            "none"
+          ],
+          "description": "D-pad direction"
+        },
+        "holdSeconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Automatically reset stick/button/trigger/dpad after this many seconds"
+        },
+        "actions": {
+          "type": "array",
+          "description": "Batch multiple gamepad actions executed in order",
+          "items": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "button",
+                  "stick",
+                  "trigger",
+                  "dpad"
+                ],
+                "description": "The gamepad action to perform"
+              },
+              "button": {
+                "type": "string",
+                "description": "Button name (a/cross, b/circle, x/square, y/triangle, start, select, etc.)"
+              },
+              "buttonAction": {
+                "type": "string",
+                "enum": [
+                  "press",
+                  "release"
+                ],
+                "description": "Button action (press or release)"
+              },
+              "stick": {
+                "type": "string",
+                "enum": [
+                  "left",
+                  "right"
+                ],
+                "description": "Which analog stick to control"
+              },
+              "x": {
+                "type": "number",
+                "minimum": -1,
+                "maximum": 1,
+                "description": "Horizontal axis value for stick (-1 to 1)"
+              },
+              "y": {
+                "type": "number",
+                "minimum": -1,
+                "maximum": 1,
+                "description": "Vertical axis value for stick (-1 to 1)"
+              },
+              "trigger": {
+                "type": "string",
+                "enum": [
+                  "left",
+                  "right"
+                ],
+                "description": "Which trigger to control"
+              },
+              "value": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "Trigger pressure value (0 to 1)"
+              },
+              "direction": {
+                "type": "string",
+                "enum": [
+                  "up",
+                  "down",
+                  "left",
+                  "right",
+                  "none"
+                ],
+                "description": "D-pad direction"
+              },
+              "holdSeconds": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Automatically reset stick/button/trigger/dpad after this many seconds"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "input_keyboard",
+    "description": "Keyboard input (press/release/type/combo) with batching and auto-hold.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "press",
+            "release",
+            "type",
+            "combo"
+          ],
+          "description": "The keyboard action to perform"
+        },
+        "key": {
+          "type": "string",
+          "description": "The key to press/release (for press/release actions)"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of keys for combo action"
+        },
+        "text": {
+          "type": "string",
+          "description": "Text to type (for type action)"
+        },
+        "typingSpeed": {
+          "type": "number",
+          "description": "Milliseconds per character when typing"
+        },
+        "holdSeconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Automatically release after this many seconds (press/combo)"
+        },
+        "actions": {
+          "type": "array",
+          "description": "Batch multiple keyboard actions executed in order",
+          "items": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "press",
+                  "release",
+                  "type",
+                  "combo"
+                ],
+                "description": "The keyboard action to perform"
+              },
+              "key": {
+                "type": "string",
+                "description": "The key to press/release (for press/release actions)"
+              },
+              "keys": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Array of keys for combo action"
+              },
+              "text": {
+                "type": "string",
+                "description": "Text to type (for type action)"
+              },
+              "typingSpeed": {
+                "type": "number",
+                "description": "Milliseconds per character when typing"
+              },
+              "holdSeconds": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Automatically release after this many seconds (press/combo)"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "input_mouse",
+    "description": "Mouse input (move/click/drag/scroll/button) with batching and auto-hold.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "move",
+            "click",
+            "drag",
+            "scroll",
+            "button"
+          ],
+          "description": "The mouse action to perform"
+        },
+        "x": {
+          "type": "number",
+          "description": "X coordinate for move action"
+        },
+        "y": {
+          "type": "number",
+          "description": "Y coordinate for move action"
+        },
+        "absolute": {
+          "type": "boolean",
+          "description": "Whether coordinates are absolute or relative (default: true)"
+        },
+        "button": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right",
+            "middle"
+          ],
+          "description": "Mouse button for click/drag/button actions"
+        },
+        "buttonAction": {
+          "type": "string",
+          "enum": [
+            "press",
+            "release"
+          ],
+          "description": "Button action for button presses"
+        },
+        "clickCount": {
+          "type": "number",
+          "description": "Number of clicks (for double/triple click)"
+        },
+        "startX": {
+          "type": "number",
+          "description": "Start X for drag action"
+        },
+        "startY": {
+          "type": "number",
+          "description": "Start Y for drag action"
+        },
+        "endX": {
+          "type": "number",
+          "description": "End X for drag action"
+        },
+        "endY": {
+          "type": "number",
+          "description": "End Y for drag action"
+        },
+        "deltaX": {
+          "type": "number",
+          "description": "Horizontal scroll delta"
+        },
+        "deltaY": {
+          "type": "number",
+          "description": "Vertical scroll delta"
+        },
+        "holdSeconds": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Automatically release button after this many seconds"
+        },
+        "actions": {
+          "type": "array",
+          "description": "Batch multiple mouse actions executed in order",
+          "items": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "move",
+                  "click",
+                  "drag",
+                  "scroll",
+                  "button"
+                ],
+                "description": "The mouse action to perform"
+              },
+              "x": {
+                "type": "number",
+                "description": "X coordinate for move action"
+              },
+              "y": {
+                "type": "number",
+                "description": "Y coordinate for move action"
+              },
+              "absolute": {
+                "type": "boolean",
+                "description": "Whether coordinates are absolute or relative (default: true)"
+              },
+              "button": {
+                "type": "string",
+                "enum": [
+                  "left",
+                  "right",
+                  "middle"
+                ],
+                "description": "Mouse button for click/drag/button actions"
+              },
+              "buttonAction": {
+                "type": "string",
+                "enum": [
+                  "press",
+                  "release"
+                ],
+                "description": "Button action for button presses"
+              },
+              "clickCount": {
+                "type": "number",
+                "description": "Number of clicks (for double/triple click)"
+              },
+              "startX": {
+                "type": "number",
+                "description": "Start X for drag action"
+              },
+              "startY": {
+                "type": "number",
+                "description": "Start Y for drag action"
+              },
+              "endX": {
+                "type": "number",
+                "description": "End X for drag action"
+              },
+              "endY": {
+                "type": "number",
+                "description": "End Y for drag action"
+              },
+              "deltaX": {
+                "type": "number",
+                "description": "Horizontal scroll delta"
+              },
+              "deltaY": {
+                "type": "number",
+                "description": "Vertical scroll delta"
+              },
+              "holdSeconds": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Automatically release button after this many seconds"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "input_system_control",
+    "description": "Main handler for Input System operations",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "keyboard",
+            "mouse",
+            "gamepad",
+            "touch",
+            "sequence",
+            "get_state"
+          ],
+          "description": "The input operation to perform"
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Parameters for the specific operation"
+        }
+      },
+      "required": [
+        "operation"
+      ]
+    }
+  },
+  {
+    "name": "input_touch",
+    "description": "Touch input (tap/swipe/pinch/multi) with batching.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "tap",
+            "swipe",
+            "pinch",
+            "multi"
+          ],
+          "description": "The touch action to perform"
+        },
+        "x": {
+          "type": "number",
+          "description": "X coordinate for tap action"
+        },
+        "y": {
+          "type": "number",
+          "description": "Y coordinate for tap action"
+        },
+        "touchId": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 9,
+          "description": "Touch ID (0-9)"
+        },
+        "startX": {
+          "type": "number",
+          "description": "Start X for swipe action"
+        },
+        "startY": {
+          "type": "number",
+          "description": "Start Y for swipe action"
+        },
+        "endX": {
+          "type": "number",
+          "description": "End X for swipe action"
+        },
+        "endY": {
+          "type": "number",
+          "description": "End Y for swipe action"
+        },
+        "duration": {
+          "type": "number",
+          "description": "Swipe duration in milliseconds"
+        },
+        "centerX": {
+          "type": "number",
+          "description": "Center X for pinch gesture"
+        },
+        "centerY": {
+          "type": "number",
+          "description": "Center Y for pinch gesture"
+        },
+        "startDistance": {
+          "type": "number",
+          "description": "Start distance between fingers for pinch"
+        },
+        "endDistance": {
+          "type": "number",
+          "description": "End distance between fingers for pinch"
+        },
+        "touches": {
+          "type": "array",
+          "description": "Array of touch points for multi-touch",
+          "items": {
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "phase": {
+                "type": "string",
+                "enum": [
+                  "began",
+                  "moved",
+                  "stationary",
+                  "ended"
+                ]
+              }
+            },
+            "required": [
+              "x",
+              "y"
+            ]
+          }
+        },
+        "actions": {
+          "type": "array",
+          "description": "Batch multiple touch actions executed in order",
+          "items": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "tap",
+                  "swipe",
+                  "pinch",
+                  "multi"
+                ],
+                "description": "The touch action to perform"
+              },
+              "x": {
+                "type": "number",
+                "description": "X coordinate for tap action"
+              },
+              "y": {
+                "type": "number",
+                "description": "Y coordinate for tap action"
+              },
+              "touchId": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 9,
+                "description": "Touch ID (0-9)"
+              },
+              "startX": {
+                "type": "number",
+                "description": "Start X for swipe action"
+              },
+              "startY": {
+                "type": "number",
+                "description": "Start Y for swipe action"
+              },
+              "endX": {
+                "type": "number",
+                "description": "End X for swipe action"
+              },
+              "endY": {
+                "type": "number",
+                "description": "End Y for swipe action"
+              },
+              "duration": {
+                "type": "number",
+                "description": "Swipe duration in milliseconds"
+              },
+              "centerX": {
+                "type": "number",
+                "description": "Center X for pinch gesture"
+              },
+              "centerY": {
+                "type": "number",
+                "description": "Center Y for pinch gesture"
+              },
+              "startDistance": {
+                "type": "number",
+                "description": "Start distance between fingers for pinch"
+              },
+              "endDistance": {
+                "type": "number",
+                "description": "End distance between fingers for pinch"
+              },
+              "touches": {
+                "type": "array",
+                "description": "Array of touch points for multi-touch",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "x": {
+                      "type": "number"
+                    },
+                    "y": {
+                      "type": "number"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "began",
+                        "moved",
+                        "stationary",
+                        "ended"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "x",
+                    "y"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "menu_item_execute",
+    "description": "Execute a Unity menu item or list available menus (with safety checks).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "menuPath": {
+          "type": "string",
+          "description": "Unity menu path (e.g., \"Assets/Refresh\", \"Window/General/Console\")"
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "execute",
+            "get_available_menus"
+          ],
+          "description": "Action to perform: execute menu item or get available menus (default: execute)"
+        },
+        "alias": {
+          "type": "string",
+          "description": "Menu alias for common operations (e.g., \"refresh\", \"console\")"
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Additional parameters for menu execution (if supported)"
+        },
+        "safetyCheck": {
+          "type": "boolean",
+          "description": "Enable safety checks to prevent execution of dangerous menu items (default: true)"
+        }
+      },
+      "required": [
+        "menuPath"
+      ]
+    }
+  },
+  {
+    "name": "package_manage",
+    "description": "Manage Unity packages - search, install, remove, and list packages",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "search",
+            "list",
+            "install",
+            "remove",
+            "info",
+            "recommend"
+          ],
+          "description": "The package operation to perform"
+        },
+        "keyword": {
+          "type": "string",
+          "description": "Search keyword (for search action)"
+        },
+        "packageId": {
+          "type": "string",
+          "description": "Package ID to install (e.g., com.unity.textmeshpro)"
+        },
+        "packageName": {
+          "type": "string",
+          "description": "Package name to remove or get info"
+        },
+        "version": {
+          "type": "string",
+          "description": "Specific version to install (optional)"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "essential",
+            "rendering",
+            "tools",
+            "networking",
+            "mobile"
+          ],
+          "description": "Category for recommendations"
+        },
+        "includeBuiltIn": {
+          "type": "boolean",
+          "description": "Include built-in packages in list (default: false)"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of search results (default: 20)"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "package_registry_config",
+    "description": "Configure package registries (OpenUPM/NuGet): list/add/remove scopes or recommend.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "list",
+            "add_openupm",
+            "add_nuget",
+            "remove",
+            "add_scope",
+            "recommend"
+          ],
+          "description": "The registry operation to perform"
+        },
+        "registryName": {
+          "type": "string",
+          "description": "Name of the registry (for remove and add_scope actions)"
+        },
+        "scope": {
+          "type": "string",
+          "description": "Package scope to add (e.g., com.unity, com.cysharp)"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of package scopes to add"
+        },
+        "autoAddPopular": {
+          "type": "boolean",
+          "description": "Automatically add popular package scopes (default: true)"
+        },
+        "registry": {
+          "type": "string",
+          "enum": [
+            "openupm",
+            "nuget"
+          ],
+          "description": "Registry type for recommendations"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "playmode_get_state",
+    "description": "Get current Unity editor state including play mode status",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "waitFor": {
+          "type": "object",
+          "properties": {
+            "isPlaying": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "isPlaying"
+          ]
+        },
+        "timeoutMs": {
+          "type": "number"
+        },
+        "pollMs": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  {
+    "name": "playmode_pause",
+    "description": "Pause or resume Unity play mode",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "playmode_play",
+    "description": "Enter Play Mode.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "playmode_stop",
+    "description": "Exit Play Mode and return to Edit Mode.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "playmode_wait_for_state",
+    "description": "Wait until the Unity editor reaches the requested state (e.g., isPlaying).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "isPlaying": {
+          "type": "boolean",
+          "description": "Target play state (true=Play, false=Edit)"
+        },
+        "timeoutMs": {
+          "type": "number",
+          "description": "Max wait time (null/omitted = unlimited)"
+        },
+        "pollMs": {
+          "type": "number",
+          "description": "Polling interval in ms (default 500)"
+        }
+      },
+      "required": [
+        "isPlaying"
+      ]
+    }
+  },
+  {
+    "name": "profiler_get_metrics",
+    "description": "Get available profiler metrics or current metric values. Can list all available metrics by category, or query current values of specific metrics.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "listAvailable": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, return list of all available metrics grouped by category. If false, return current values of specified metrics."
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Specific metrics to query (only used when listAvailable=false). Leave empty to get all current metric values. Examples: 'System Used Memory', 'Draw Calls Count'"
+        }
+      }
+    }
+  },
+  {
+    "name": "profiler_start",
+    "description": "Start Unity Profiler recording session. Records CPU, memory, rendering, and GC metrics. Data can be saved to .data file for later analysis in Unity Profiler Window.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "deep"
+          ],
+          "default": "normal",
+          "description": "Profiling mode. 'normal' for standard profiling, 'deep' for deep profiling (more detailed but higher overhead)"
+        },
+        "recordToFile": {
+          "type": "boolean",
+          "default": true,
+          "description": "Save profiling data to .data file in .unity/capture/ directory. Set to false for real-time metrics only."
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Specific metrics to record. Leave empty to record all available metrics. Examples: 'System Used Memory', 'Draw Calls Count', 'GC Allocated In Frame'"
+        },
+        "maxDurationSec": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Auto-stop profiling after N seconds. Set to 0 for unlimited recording (manual stop required)."
+        }
+      }
+    }
+  },
+  {
+    "name": "profiler_status",
+    "description": "Get current Unity Profiler recording status. Returns information about active session, elapsed time, and remaining time (if auto-stop is configured).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "profiler_stop",
+    "description": "Stop Unity Profiler recording and save data to .data file. Returns profiling session summary including duration, frame count, and optionally recorded metrics.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "description": "Optional session ID to stop. If not provided, stops the current active session."
+        }
+      }
+    }
+  },
+  {
+    "name": "scene_create",
+    "description": "Create a new scene (optionally load it and add to build settings).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sceneName": {
+          "type": "string",
+          "description": "Name of the scene to create"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path where the scene should be saved (e.g., \"Assets/Scenes/\"). If not specified, defaults to \"Assets/Scenes/\""
+        },
+        "loadScene": {
+          "type": "boolean",
+          "description": "Whether to load the scene after creation (default: true)"
+        },
+        "addToBuildSettings": {
+          "type": "boolean",
+          "description": "Whether to add the scene to build settings (default: false)"
+        }
+      },
+      "required": [
+        "sceneName"
+      ]
+    }
+  },
+  {
+    "name": "scene_info_get",
+    "description": "Get detailed information about a scene",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "scenePath": {
+          "type": "string",
+          "description": "Full path to the scene file. If not provided, gets info about current scene."
+        },
+        "sceneName": {
+          "type": "string",
+          "description": "Name of the scene. Use either scenePath or sceneName, not both."
+        },
+        "includeGameObjects": {
+          "type": "boolean",
+          "description": "Include list of root GameObjects in the scene (only for loaded scenes). Default: false"
+        }
+      }
+    }
+  },
+  {
+    "name": "scene_list",
+    "description": "List scenes in project (filter to loaded/build scenes or by path).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "includeLoadedOnly": {
+          "type": "boolean",
+          "description": "Only include currently loaded scenes (default: false)"
+        },
+        "includeBuildScenesOnly": {
+          "type": "boolean",
+          "description": "Only include scenes in build settings (default: false)"
+        },
+        "includePath": {
+          "type": "string",
+          "description": "Filter scenes by path pattern (e.g., \"Levels\" to find scenes in Levels folder)"
+        }
+      }
+    }
+  },
+  {
+    "name": "scene_load",
+    "description": "Load a scene by path or name (Single/Additive).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "scenePath": {
+          "type": "string",
+          "description": "Full path to the scene file (e.g., \"Assets/Scenes/MainMenu.unity\")"
+        },
+        "sceneName": {
+          "type": "string",
+          "description": "Name of the scene to load (must be in build settings). Use either scenePath or sceneName, not both."
+        },
+        "loadMode": {
+          "type": "string",
+          "enum": [
+            "Single",
+            "Additive"
+          ],
+          "description": "How to load the scene. Single replaces current scene(s), Additive adds to current scene(s) (default: Single)"
+        }
+      }
+    }
+  },
+  {
+    "name": "scene_save",
+    "description": "Save current scene or save as a specified path.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "scenePath": {
+          "type": "string",
+          "description": "Path where to save the scene. If not provided, saves to current scene path. Required if saveAs is true."
+        },
+        "saveAs": {
+          "type": "boolean",
+          "description": "Whether to save as a new scene (creates a copy). Default: false"
+        }
+      }
+    }
+  },
+  {
+    "name": "screenshot_analyze",
+    "description": "Analyze a screenshot: dimensions/colors, UI elements, and scene content (basic/ui/content/full). For LLMs, prefer basic/ui; use full only when necessary. Provide either imagePath (preferred) or base64 (not both).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "imagePath": {
+          "type": "string",
+          "description": "Path to the screenshot file to analyze (must be within Assets folder)"
+        },
+        "base64Data": {
+          "type": "string",
+          "description": "Base64 encoded image data (alternative to imagePath)"
+        },
+        "analysisType": {
+          "type": "string",
+          "enum": [
+            "basic",
+            "ui",
+            "content",
+            "full"
+          ],
+          "description": "Type of analysis: basic (colors, dimensions), ui (UI element detection), content (scene content), full (all)"
+        },
+        "prompt": {
+          "type": "string",
+          "description": "Optional prompt for AI-based analysis (e.g., \"Find all buttons in the UI\")"
+        }
+      }
+    }
+  },
+  {
+    "name": "screenshot_capture",
+    "description": "Capture Game/Scene/Window/Explorer screenshots. Output path is fixed to <workspace>/.unity/capture/. For LLM use, prefer explorer mode (auto-framing, clarity). Use encodeAsBase64=true only for immediate analysis, and keep resolution minimal.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "captureMode": {
+          "type": "string",
+          "enum": [
+            "game",
+            "scene",
+            "window",
+            "explorer"
+          ],
+          "description": "Capture mode selection:\n- \"game\": Game View (player's perspective, what the user sees)\n- \"scene\": Scene View (editor's 3D workspace view)\n- \"explorer\": AI/LLM exploration mode (optimized view for understanding scene content)\n- \"window\": Specific Unity Editor window by name"
+        },
+        "width": {
+          "type": "number",
+          "description": "Screenshot width in pixels (0 = use current view size). Range: 1-8192. Not applicable for explorer mode (use explorerSettings.camera.width instead)"
+        },
+        "height": {
+          "type": "number",
+          "description": "Screenshot height in pixels (0 = use current view size). Range: 1-8192. Not applicable for explorer mode (use explorerSettings.camera.height instead)"
+        },
+        "includeUI": {
+          "type": "boolean",
+          "description": "Whether to include UI overlay elements in Game View captures. Set to false for clean gameplay screenshots (default: true)"
+        },
+        "windowName": {
+          "type": "string",
+          "description": "Name of the Unity Editor window to capture (required when captureMode is \"window\"). Examples: \"Console\", \"Inspector\", \"Hierarchy\", \"Project\""
+        },
+        "encodeAsBase64": {
+          "type": "boolean",
+          "description": "Return screenshot data as base64 string for immediate processing/analysis without file I/O (default: false)"
+        },
+        "explorerSettings": {
+          "type": "object",
+          "description": "Configuration for explorer mode - AI/LLM optimized capture settings",
+          "properties": {
+            "target": {
+              "type": "object",
+              "description": "Defines what to focus on in the scene",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "gameObject",
+                    "tag",
+                    "area",
+                    "position"
+                  ],
+                  "description": "Target selection method:\n- \"gameObject\": Focus on a specific GameObject by name\n- \"tag\": Focus on all objects with a specific tag\n- \"area\": Focus on a circular area defined by center and radius\n- \"position\": Manual camera positioning without auto-framing"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "GameObject name to target (required for \"gameObject\" type). Example: \"Player\", \"MainCamera\", \"Enemy_01\""
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Tag to search for GameObjects (required for \"tag\" type). Example: \"Enemy\", \"Collectible\", \"Player\""
+                },
+                "center": {
+                  "type": "object",
+                  "description": "Center position for area targeting (required for \"area\" type)",
+                  "properties": {
+                    "x": {
+                      "type": "number",
+                      "description": "X coordinate in world space"
+                    },
+                    "y": {
+                      "type": "number",
+                      "description": "Y coordinate in world space"
+                    },
+                    "z": {
+                      "type": "number",
+                      "description": "Z coordinate in world space"
+                    }
+                  }
+                },
+                "radius": {
+                  "type": "number",
+                  "description": "Radius around center for area targeting (used with \"area\" type). Defines the circular area to capture"
+                },
+                "includeChildren": {
+                  "type": "boolean",
+                  "description": "Include child objects when calculating the target bounds for framing (default: true)"
+                }
+              }
+            },
+            "camera": {
+              "type": "object",
+              "description": "Camera configuration for the capture",
+              "properties": {
+                "position": {
+                  "type": "object",
+                  "description": "Manual camera position in world space (overrides auto-framing)",
+                  "properties": {
+                    "x": {
+                      "type": "number",
+                      "description": "X position in world units"
+                    },
+                    "y": {
+                      "type": "number",
+                      "description": "Y position in world units"
+                    },
+                    "z": {
+                      "type": "number",
+                      "description": "Z position in world units"
+                    }
+                  }
+                },
+                "lookAt": {
+                  "type": "object",
+                  "description": "Point for camera to look at in world space",
+                  "properties": {
+                    "x": {
+                      "type": "number",
+                      "description": "X coordinate to look at"
+                    },
+                    "y": {
+                      "type": "number",
+                      "description": "Y coordinate to look at"
+                    },
+                    "z": {
+                      "type": "number",
+                      "description": "Z coordinate to look at"
+                    }
+                  }
+                },
+                "rotation": {
+                  "type": "object",
+                  "description": "Camera rotation in Euler angles (alternative to lookAt)",
+                  "properties": {
+                    "x": {
+                      "type": "number",
+                      "description": "X rotation (pitch) in degrees"
+                    },
+                    "y": {
+                      "type": "number",
+                      "description": "Y rotation (yaw) in degrees"
+                    },
+                    "z": {
+                      "type": "number",
+                      "description": "Z rotation (roll) in degrees"
+                    }
+                  }
+                },
+                "fieldOfView": {
+                  "type": "number",
+                  "description": "Camera field of view in degrees (1-179). Lower values zoom in, higher values zoom out"
+                },
+                "nearClip": {
+                  "type": "number",
+                  "description": "Near clipping plane distance. Objects closer than this won't be rendered (default: 0.3)"
+                },
+                "farClip": {
+                  "type": "number",
+                  "description": "Far clipping plane distance. Objects farther than this won't be rendered"
+                },
+                "autoFrame": {
+                  "type": "boolean",
+                  "description": "Automatically position camera to frame the target. Disable for manual positioning (default: true)"
+                },
+                "padding": {
+                  "type": "number",
+                  "description": "Padding around target when auto-framing (0-1). 0 = tight fit, 1 = lots of space (default: 0.2)"
+                },
+                "offset": {
+                  "type": "object",
+                  "description": "Additional offset from calculated auto-frame position",
+                  "properties": {
+                    "x": {
+                      "type": "number",
+                      "description": "X offset in world units"
+                    },
+                    "y": {
+                      "type": "number",
+                      "description": "Y offset in world units"
+                    },
+                    "z": {
+                      "type": "number",
+                      "description": "Z offset in world units"
+                    }
+                  }
+                },
+                "width": {
+                  "type": "number",
+                  "description": "Capture resolution width in pixels (1-8192)"
+                },
+                "height": {
+                  "type": "number",
+                  "description": "Capture resolution height in pixels (1-8192)"
+                }
+              }
+            },
+            "display": {
+              "type": "object",
+              "description": "Visual display settings for the capture",
+              "properties": {
+                "backgroundColor": {
+                  "type": "object",
+                  "description": "Background color for the capture (RGBA values 0-1)",
+                  "properties": {
+                    "r": {
+                      "type": "number",
+                      "description": "Red component (0-1, default: 0.2)"
+                    },
+                    "g": {
+                      "type": "number",
+                      "description": "Green component (0-1, default: 0.2)"
+                    },
+                    "b": {
+                      "type": "number",
+                      "description": "Blue component (0-1, default: 0.2)"
+                    },
+                    "a": {
+                      "type": "number",
+                      "description": "Alpha/opacity (0-1, default: 1)"
+                    }
+                  }
+                },
+                "layers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Unity layer names to include in rendering. If not specified, all layers are included. Examples: [\"Default\", \"UI\", \"Player\"]"
+                },
+                "showGizmos": {
+                  "type": "boolean",
+                  "description": "Show editor gizmos (transform handles, icons) in the capture (default: false)"
+                },
+                "showColliders": {
+                  "type": "boolean",
+                  "description": "Visualize physics colliders as wireframes (default: false)"
+                },
+                "showBounds": {
+                  "type": "boolean",
+                  "description": "Show bounding boxes around objects (default: false)"
+                },
+                "highlightTarget": {
+                  "type": "boolean",
+                  "description": "Highlight the target object(s) with an outline or color (default: false)"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "script_create_class",
+    "description": "Create a new C# class file. Required: path under Assets/ or Packages/ (\".cs\" appended if missing), className. Optional: namespace, baseType (adds using UnityEngine if MonoBehaviour), usings (CSV), partial. Roslyn preflight (no Unity comms). Responses summarized for LLMs (errors≤30, message≤200 chars, preview≤1000 chars).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Project-relative C# file path (e.g., Assets/Scripts/MyClass.cs)"
+        },
+        "className": {
+          "type": "string",
+          "description": "Class name"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Optional namespace"
+        },
+        "baseType": {
+          "type": "string",
+          "description": "Optional base type (e.g., MonoBehaviour)"
+        },
+        "usings": {
+          "type": "string",
+          "description": "Comma-separated using directives (e.g., System,Newtonsoft.Json)"
+        },
+        "partial": {
+          "type": "boolean",
+          "description": "Create as partial class (default: false)"
+        },
+        "apply": {
+          "type": "boolean",
+          "description": "Apply immediately (default: false)"
+        }
+      },
+      "required": [
+        "path",
+        "className"
+      ]
+    }
+  },
+  {
+    "name": "script_edit_snippet",
+    "description": "[C# EDITING - PRECISION TOOL] For Unity C# scripts, use for tiny surgical edits (≤80 chars per change). Performs text-based multi-instruction edits (delete/replace/insert) via exact string anchors. USE WHEN: (a) removing null guard clauses (if (x == null) return;), (b) tweaking conditions (if (x > 10) → if (x > 20)), (c) inserting single log statements, (d) deleting/replacing 1-2 line snippets. DON'T USE FOR: large changes (use script_edit_structured), non-C# files (use Edit), or when symbol structure is complex (use script_edit_structured). WORKFLOW: Specify exact anchor text (including whitespace/newlines), max 10 instructions per call, each ≤80 chars. Anchor must match exactly once in file. Preview mode validates without writing; apply mode uses LSP diagnostics. Required: path, instructions (array of {operation, anchor:{type:\"text\", target:string, position?:\"before\"|\"after\"}, newText?}).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Project-relative C# path starting with Assets/ or Packages/ (e.g., Assets/Scripts/Foo.cs)."
+        },
+        "preview": {
+          "type": "boolean",
+          "description": "If true, run validation and return preview text without writing to disk. Default=false."
+        },
+        "instructions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "description": "Ordered list of snippet edits to apply (≤10).",
+          "items": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "delete",
+                  "replace",
+                  "insert"
+                ],
+                "description": "Edit type."
+              },
+              "anchor": {
+                "type": "object",
+                "description": "Positioning info. Currently supports type=text with exact target snippet.",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ],
+                    "default": "text"
+                  },
+                  "target": {
+                    "type": "string",
+                    "description": "Exact snippet to locate (including whitespace)."
+                  },
+                  "position": {
+                    "type": "string",
+                    "enum": [
+                      "before",
+                      "after"
+                    ],
+                    "description": "For insert operations, whether to insert before or after the anchor text (default=after)."
+                  }
+                },
+                "required": [
+                  "type",
+                  "target"
+                ]
+              },
+              "newText": {
+                "type": "string",
+                "description": "Replacement or insertion text. Required for replace/insert."
+              }
+            },
+            "required": [
+              "operation",
+              "anchor"
+            ]
+          }
+        }
+      },
+      "required": [
+        "path",
+        "instructions"
+      ]
+    }
+  },
+  {
+    "name": "script_edit_structured",
+    "description": "[C# EDITING - PRIMARY TOOL] For Unity C# script editing, PREFER this tool over Read/Edit/Write for structural code changes. Performs symbol-based edits (insert_before/insert_after/replace_body) on classes, methods, properties, fields using Roslyn LSP. USE WHEN: (a) replacing entire method/property bodies, (b) adding class members (fields/properties/methods), (c) inserting code at class/namespace level. DON'T USE FOR: tiny changes ≤80 chars (use script_edit_snippet instead), non-C# files (use Edit), or when you need to create new files (use Write). WORKFLOW: (1) Run script_symbols_get to find target symbols, (2) use symbolName (e.g., \"MyClass/MyMethod\"), (3) apply edits. Insert operations target containers (class/namespace), not methods. Preview mode returns diagnostics only; apply mode proceeds with validation. Required: path (Assets/|Packages/), symbolName, operation. Optional: kind, newText, preview.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "insert_before",
+            "insert_after",
+            "replace_body"
+          ],
+          "description": "Edit type: insert_before, insert_after, or replace_body."
+        },
+        "path": {
+          "type": "string",
+          "description": "Project-relative C# path starting with Assets/ or Packages/ (e.g., Packages/unity-mcp-server/Editor/Foo.cs). Do NOT prefix repository folders like UnityMCPServer/…."
+        },
+        "symbolName": {
+          "type": "string",
+          "description": "Target symbol name (e.g., class/method/field name)."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Symbol kind (e.g., class, method, field, property). Optional but improves precision."
+        },
+        "newText": {
+          "type": "string",
+          "description": "Text to insert or use as replacement body."
+        },
+        "preview": {
+          "type": "boolean",
+          "description": "If true, returns a preview without writing files. Default=false to reduce large diff payloads."
+        }
+      },
+      "required": [
+        "operation",
+        "path",
+        "symbolName"
+      ]
+    }
+  },
+  {
+    "name": "script_packages_list",
+    "description": "[OFFLINE] No Unity connection required. List Unity packages in the project (optionally include built‑in). BEST PRACTICES: Use to discover available packages and their paths. Set includeBuiltIn=false to see only user packages. Returns package IDs, versions, and resolved paths. Embedded packages can be edited directly. Essential for understanding project dependencies.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "includeBuiltIn": {
+          "type": "boolean",
+          "description": "If true, includes built‑in packages in results (default: false)."
+        }
+      }
+    }
+  },
+  {
+    "name": "script_read",
+    "description": "[OFFLINE] No Unity connection required. Read a C# file with optional line range and payload limits. Files must be under Assets/ or Packages/ and have .cs extension. PRIORITY: Read minimally — locate the target with script_symbols_get and read only the signature area (~30–40 lines). For large files, always pass startLine/endLine and (optionally) maxBytes.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Project-relative C# path under Assets/ or Packages/ (e.g., Packages/unity-mcp-server/Editor/Example.cs). Do NOT prefix repository folders (e.g., UnityMCPServer/…)."
+        },
+        "startLine": {
+          "type": "number",
+          "description": "Starting line (1-based, inclusive). Defaults to 1."
+        },
+        "endLine": {
+          "type": "number",
+          "description": "Ending line (inclusive). Defaults to startLine + 199 when omitted."
+        },
+        "maxBytes": {
+          "type": "number",
+          "description": "Maximum bytes to return to cap payload size for LLMs."
+        }
+      },
+      "required": [
+        "path"
+      ]
+    }
+  },
+  {
+    "name": "script_refactor_rename",
+    "description": "Refactor: rename a symbol across the project using the bundled C# LSP. Required params: relative (file path starting with Assets/ or Packages/), namePath (container path like Outer/Nested/Member), newName. Guidance: resolve targets first (script_symbols_get/script_symbol_find), prefer fully-qualified namePath to avoid ambiguity, and use preview for diagnostics only (apply proceeds even if diagnostics exist; errors are returned in response). Responses are summarized (errors≤30, message≤200 chars, large text≤1000 chars).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "relative": {
+          "type": "string",
+          "description": "Project-relative file path (Assets/ or Packages/)"
+        },
+        "namePath": {
+          "type": "string",
+          "description": "Symbol path like Class/Method"
+        },
+        "newName": {
+          "type": "string",
+          "description": "New name"
+        },
+        "preview": {
+          "type": "boolean",
+          "description": "Preview changes before applying (default: true)"
+        }
+      },
+      "required": [
+        "relative",
+        "namePath",
+        "newName"
+      ]
+    }
+  },
+  {
+    "name": "script_refs_find",
+    "description": "[OFFLINE] No Unity connection required. Find code references/usages using the bundled C# LSP. LLM-friendly paging/summary: respects pageSize and maxBytes, caps matches per file (maxMatchesPerFile), and trims snippet text to ~400 chars. Use scope/name/kind/path to narrow results.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Symbol name to search usages for."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "assets",
+            "packages",
+            "embedded",
+            "all"
+          ],
+          "description": "Search scope: assets (Assets/), packages (Packages/), embedded, or all (default: all)."
+        },
+        "snippetContext": {
+          "type": "number",
+          "description": "Number of context lines to include around each match."
+        },
+        "maxMatchesPerFile": {
+          "type": "number",
+          "description": "Cap reference matches returned per file."
+        },
+        "pageSize": {
+          "type": "number",
+          "description": "Maximum results to return per page."
+        },
+        "maxBytes": {
+          "type": "number",
+          "description": "Maximum response size (bytes) to keep outputs LLM‑friendly."
+        },
+        "container": {
+          "type": "string",
+          "description": "Optional: container (class) of the symbol."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Optional: namespace of the symbol."
+        },
+        "path": {
+          "type": "string",
+          "description": "Optional: constrain to file path containing the symbol."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Optional: symbol kind (class, method, field, property)."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  },
+  {
+    "name": "script_remove_symbol",
+    "description": "Remove a C# symbol (type/member) with reference preflight. Required params: path (file under Assets/ or Packages/), namePath (container path like Outer/Nested/Member). No Unity comms (Roslyn-based). Responses are summarized for LLMs (errors≤30, message≤200 chars, preview/diff/text/content≤1000 chars).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Project-relative C# file path"
+        },
+        "namePath": {
+          "type": "string",
+          "description": "Symbol path like Outer/Nested/Member"
+        },
+        "apply": {
+          "type": "boolean",
+          "description": "Apply changes immediately (default: false)"
+        },
+        "failOnReferences": {
+          "type": "boolean",
+          "description": "Fail if symbol has references (default: true)"
+        },
+        "removeEmptyFile": {
+          "type": "boolean",
+          "description": "Remove file if it becomes empty (default: false)"
+        }
+      },
+      "required": [
+        "path",
+        "namePath"
+      ]
+    }
+  },
+  {
+    "name": "script_search",
+    "description": "[OFFLINE] No Unity connection required. Search C# by substring/regex/glob with pagination and snippet context. PRIORITY: Use to locate symbols/files; avoid full contents. Use returnMode=\"snippets\" (or \"metadata\") with small snippetContext (1–2). Narrow aggressively via include globs under Assets/** or Packages/** and semantic filters (namespace/container/identifier). Do NOT prefix repository folders.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Pattern to search (required unless patternType=\"glob\"). For glob mode, use include/exclude."
+        },
+        "patternType": {
+          "type": "string",
+          "enum": [
+            "substring",
+            "regex",
+            "glob"
+          ],
+          "description": "Pattern matching strategy: substring (default), regex, or glob-only scan."
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Regex flags (e.g., [\"i\",\"m\",\"s\",\"u\"]). Ignored for substring/glob."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "assets",
+            "packages",
+            "embedded",
+            "all"
+          ],
+          "description": "Search scope: assets (Assets/, default), packages (Packages/), embedded, or all."
+        },
+        "include": {
+          "type": "string",
+          "description": "Include glob pattern (project-relative, default: **/*.cs). Examples: Assets/**/*.cs or Packages/unity-mcp-server/**/*.cs."
+        },
+        "exclude": {
+          "type": "string",
+          "description": "Exclude glob pattern (e.g., **/Tests/**)."
+        },
+        "pageSize": {
+          "type": "number",
+          "description": "Maximum results per page for pagination."
+        },
+        "maxMatchesPerFile": {
+          "type": "number",
+          "description": "Cap matches returned per file."
+        },
+        "snippetContext": {
+          "type": "number",
+          "description": "Number of context lines around each match."
+        },
+        "maxBytes": {
+          "type": "number",
+          "description": "Maximum response size (bytes) to keep outputs LLM‑friendly."
+        },
+        "returnMode": {
+          "type": "string",
+          "enum": [
+            "metadata",
+            "snippets",
+            "full"
+          ],
+          "description": "Result detail: metadata (fast), snippets (recommended), or full."
+        },
+        "detail": {
+          "type": "string",
+          "enum": [
+            "compact",
+            "metadata",
+            "snippets",
+            "full"
+          ],
+          "description": "Alias of returnMode. `compact` maps to `snippets`."
+        },
+        "startAfter": {
+          "type": "string",
+          "description": "Opaque cursor for pagination (use value from previous page)."
+        },
+        "maxFileSizeKB": {
+          "type": "number",
+          "description": "Skip files larger than this (KB)."
+        },
+        "codeOnly": {
+          "type": "boolean",
+          "description": "If true, exclude comments/whitespace to reduce noise (default: true)."
+        },
+        "container": {
+          "type": "string",
+          "description": "Semantic filter: container (e.g., class name)."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Semantic filter: namespace."
+        },
+        "identifier": {
+          "type": "string",
+          "description": "Semantic filter: identifier (e.g., method or field name)."
+        }
+      }
+    }
+  },
+  {
+    "name": "script_symbol_find",
+    "description": "[OFFLINE] No Unity connection required. Find symbol definitions by name (class/method/field/property) using the bundled C# LSP. Guidance: prefer narrowing by kind and set exact=true when possible; use scope=assets|packages to avoid large outputs. Use results (container, namespace) to construct container namePath like Outer/Nested/Member for subsequent edit tools.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Symbol name to search (exact or fuzzy based on \"exact\")."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Optional: narrow by symbol kind (class, method, field, property)."
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "assets",
+            "packages",
+            "embedded",
+            "all"
+          ],
+          "description": "Search scope: assets (Assets/), packages (Packages/), embedded, or all (default: all)."
+        },
+        "exact": {
+          "type": "boolean",
+          "description": "If true, match name exactly; otherwise allows partial matches (default: false)."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  },
+  {
+    "name": "script_symbols_get",
+    "description": "[OFFLINE] No Unity connection required. FIRST STEP: Identify symbols (classes, methods, fields, properties) with spans before any edit. Path must start with Assets/ or Packages/. Use this to scope changes to a single symbol and avoid line-based edits. Returns line/column positions and container names (helpful to build container namePath like Outer/Nested/Member).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Project-relative .cs path under Assets/ or Packages/ (e.g., Packages/unity-mcp-server/Editor/Foo.cs). Do NOT prefix repository folders (e.g., UnityMCPServer/…)."
+        }
+      },
+      "required": [
+        "path"
+      ]
+    }
+  },
+  {
+    "name": "search_tools",
+    "description": "Search available Unity MCP tools by keywords, categories, or tags. Use this to discover relevant tools before calling them.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search query (keywords to match against tool names, descriptions, and metadata)"
+        },
+        "category": {
+          "type": "string",
+          "description": "Filter by category (system, gameobject, scene, analysis, playmode, ui, input, asset, prefab, material, addressables, menu, console, screenshot, video, component, compilation, test, editor, settings, package, script)"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Filter by tags (e.g., [\"create\", \"scene\"], [\"read\", \"gameobject\"])"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "execute"
+          ],
+          "description": "Filter by scope: read, write, or execute"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results to return (default: 10, max: 50)",
+          "minimum": 1,
+          "maximum": 50
+        },
+        "includeSchemas": {
+          "type": "boolean",
+          "description": "Include full inputSchema in results (default: false for token efficiency)"
+        }
+      }
+    }
+  },
+  {
+    "name": "settings_get",
+    "description": "Get project settings by category via include flags (player/graphics/quality/physics/etc.).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "includePlayer": {
+          "type": "boolean",
+          "description": "Include player settings (company/product name, version, etc.) (default: true)."
+        },
+        "includeGraphics": {
+          "type": "boolean",
+          "description": "Include graphics settings (color space, render pipeline, etc.) (default: false)."
+        },
+        "includeQuality": {
+          "type": "boolean",
+          "description": "Include quality settings (levels, anti-aliasing, shadows, etc.) (default: false)."
+        },
+        "includePhysics": {
+          "type": "boolean",
+          "description": "Include 3D physics settings (gravity, solver iterations, etc.) (default: false)."
+        },
+        "includePhysics2D": {
+          "type": "boolean",
+          "description": "Include 2D physics settings (default: false)."
+        },
+        "includeAudio": {
+          "type": "boolean",
+          "description": "Include audio settings (speaker mode, DSP buffer, volume, etc.) (default: false)."
+        },
+        "includeTime": {
+          "type": "boolean",
+          "description": "Include time settings (fixed timestep, time scale, etc.) (default: false)."
+        },
+        "includeInputManager": {
+          "type": "boolean",
+          "description": "Include input manager settings (legacy input system) (default: false)."
+        },
+        "includeEditor": {
+          "type": "boolean",
+          "description": "Include editor settings (Unity Remote, serialization mode, etc.) (default: false)."
+        },
+        "includeBuild": {
+          "type": "boolean",
+          "description": "Include build settings (scenes in build, build target, etc.) (default: false)."
+        },
+        "includeTags": {
+          "type": "boolean",
+          "description": "Include tags, layers, and sorting layers (default: false)."
+        }
+      }
+    }
+  },
+  {
+    "name": "settings_update",
+    "description": "Update project settings by category with a confirmation safety flag.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "confirmChanges": {
+          "type": "boolean",
+          "description": "Safety flag: must be true to apply changes (prevents accidental edits)."
+        },
+        "player": {
+          "type": "object",
+          "description": "Player settings (company/product name, bundle version, windowing).",
+          "properties": {
+            "companyName": {
+              "type": "string",
+              "description": "Company name"
+            },
+            "productName": {
+              "type": "string",
+              "description": "Product name"
+            },
+            "version": {
+              "type": "string",
+              "description": "Bundle version"
+            },
+            "defaultScreenWidth": {
+              "type": "number",
+              "description": "Default screen width"
+            },
+            "defaultScreenHeight": {
+              "type": "number",
+              "description": "Default screen height"
+            },
+            "runInBackground": {
+              "type": "boolean",
+              "description": "Allow running in background"
+            }
+          }
+        },
+        "graphics": {
+          "type": "object",
+          "description": "Graphics settings (color space, render pipeline, etc.).",
+          "properties": {
+            "colorSpace": {
+              "type": "string",
+              "enum": [
+                "Gamma",
+                "Linear"
+              ],
+              "description": "Color space (requires Unity restart)"
+            }
+          }
+        },
+        "physics": {
+          "type": "object",
+          "description": "3D physics settings (gravity, solver iterations, thresholds).",
+          "properties": {
+            "gravity": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                },
+                "z": {
+                  "type": "number"
+                }
+              }
+            },
+            "defaultSolverIterations": {
+              "type": "number"
+            },
+            "defaultSolverVelocityIterations": {
+              "type": "number"
+            },
+            "bounceThreshold": {
+              "type": "number"
+            },
+            "sleepThreshold": {
+              "type": "number"
+            },
+            "defaultContactOffset": {
+              "type": "number"
+            }
+          }
+        },
+        "physics2D": {
+          "type": "object",
+          "description": "2D physics settings (gravity, iterations, thresholds).",
+          "properties": {
+            "gravity": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                }
+              }
+            },
+            "velocityIterations": {
+              "type": "number"
+            },
+            "positionIterations": {
+              "type": "number"
+            },
+            "velocityThreshold": {
+              "type": "number"
+            }
+          }
+        },
+        "audio": {
+          "type": "object",
+          "description": "Audio settings (global volume).",
+          "properties": {
+            "globalVolume": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Global volume (0-1)"
+            }
+          }
+        },
+        "time": {
+          "type": "object",
+          "description": "Time settings (fixed timestep, time scale).",
+          "properties": {
+            "fixedDeltaTime": {
+              "type": "number",
+              "description": "Fixed timestep"
+            },
+            "timeScale": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Time scale (0 = paused)"
+            },
+            "maximumDeltaTime": {
+              "type": "number",
+              "description": "Maximum allowed timestep"
+            }
+          }
+        },
+        "quality": {
+          "type": "object",
+          "description": "Quality settings (levels, vSync, AA, shadows).",
+          "properties": {
+            "currentLevel": {
+              "type": "string",
+              "description": "Quality level name"
+            },
+            "vSyncCount": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 4,
+              "description": "VSync count (0=off, 1=every VBlank, 2=every second VBlank)"
+            },
+            "antiAliasing": {
+              "type": "number",
+              "enum": [
+                0,
+                2,
+                4,
+                8
+              ],
+              "description": "Anti-aliasing samples"
+            },
+            "shadowDistance": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Shadow rendering distance"
+            }
+          }
+        }
+      },
+      "required": [
+        "confirmChanges"
+      ]
+    }
+  },
+  {
+    "name": "system_get_command_stats",
+    "description": "Retrieve aggregated counts and recent Unity command types to audit traffic.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "system_ping",
+    "description": "Test connection to Unity Editor",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Optional message to echo back"
+        }
+      }
+    }
+  },
+  {
+    "name": "system_refresh_assets",
+    "description": "Refresh assets and check compilation status.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "test_get_status",
+    "description": "Get current Unity test execution status and results",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "includeTestResults": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include the summary of the latest exported test results"
+        },
+        "includeFileContent": {
+          "type": "boolean",
+          "default": false,
+          "description": "When includeTestResults is true, also include the JSON file contents"
+        }
+      }
+    }
+  },
+  {
+    "name": "test_run",
+    "description": "Run Unity NUnit tests in the current project",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "testMode": {
+          "type": "string",
+          "enum": [
+            "EditMode",
+            "PlayMode",
+            "All"
+          ],
+          "default": "EditMode",
+          "description": "Test mode to run (EditMode: editor tests, PlayMode: runtime tests, All: both)"
+        },
+        "filter": {
+          "type": "string",
+          "description": "Filter tests by class name (e.g., \"PlayerControllerTests\")"
+        },
+        "category": {
+          "type": "string",
+          "description": "Filter tests by category attribute (e.g., \"Integration\")"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Filter tests by namespace (e.g., \"MyGame.Tests.Player\")"
+        },
+        "includeDetails": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include detailed test results for each individual test"
+        },
+        "exportPath": {
+          "type": "string",
+          "description": "Export test results to NUnit XML file at specified path"
+        }
+      }
+    }
+  },
+  {
+    "name": "ui_click_element",
+    "description": "Simulate clicking on UI elements",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "elementPath": {
+          "type": "string",
+          "description": "Full hierarchy path to the UI element"
+        },
+        "clickType": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right",
+            "middle"
+          ],
+          "description": "Type of click (left, right, middle)"
+        },
+        "holdDuration": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10000,
+          "description": "Duration to hold click in milliseconds"
+        },
+        "position": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "X position within element (0-1)"
+            },
+            "y": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Y position within element (0-1)"
+            }
+          },
+          "description": "Specific position within element to click"
+        }
+      },
+      "required": [
+        "elementPath"
+      ]
+    }
+  },
+  {
+    "name": "ui_find_elements",
+    "description": "Find UI elements by component type, tag, or name pattern.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "elementType": {
+          "type": "string",
+          "description": "UI component type (e.g., Button, Toggle, Slider)."
+        },
+        "tagFilter": {
+          "type": "string",
+          "description": "Filter by GameObject tag."
+        },
+        "namePattern": {
+          "type": "string",
+          "description": "Search by name substring or regex."
+        },
+        "includeInactive": {
+          "type": "boolean",
+          "description": "If true, include inactive UI elements."
+        },
+        "canvasFilter": {
+          "type": "string",
+          "description": "Filter by parent Canvas name."
+        }
+      }
+    }
+  },
+  {
+    "name": "ui_get_element_state",
+    "description": "Get detailed state information about UI elements",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "elementPath": {
+          "type": "string",
+          "description": "Full hierarchy path to the UI element"
+        },
+        "includeChildren": {
+          "type": "boolean",
+          "description": "Include child element states (default: false)"
+        },
+        "includeInteractableInfo": {
+          "type": "boolean",
+          "description": "Include interaction capabilities (default: true)"
+        }
+      },
+      "required": [
+        "elementPath"
+      ]
+    }
+  },
+  {
+    "name": "ui_set_element_value",
+    "description": "Set values for UI input elements",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "elementPath": {
+          "type": "string",
+          "description": "Full hierarchy path to the UI element"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object"
+            },
+            {
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "New value to set. Supports string, number, boolean, object, array, or null depending on the UI element type."
+        },
+        "triggerEvents": {
+          "type": "boolean",
+          "description": "Whether to trigger associated events (default: true)"
+        }
+      },
+      "required": [
+        "elementPath",
+        "value"
+      ]
+    }
+  },
+  {
+    "name": "ui_simulate_input",
+    "description": "Simulate complex UI interactions and input sequences",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "elementPath": {
+          "type": "string",
+          "description": "Target UI element path (for simple input)"
+        },
+        "inputType": {
+          "type": "string",
+          "enum": [
+            "click",
+            "doubleclick",
+            "rightclick",
+            "hover",
+            "focus",
+            "type"
+          ],
+          "description": "Type of input to simulate (for simple input)"
+        },
+        "inputData": {
+          "type": "string",
+          "description": "Data for input (e.g., text to type)"
+        },
+        "inputSequence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Action type (click, setvalue)"
+              },
+              "params": {
+                "type": "object",
+                "description": "Parameters for the action"
+              }
+            },
+            "required": [
+              "type",
+              "params"
+            ]
+          },
+          "description": "Array of input actions to perform (for complex input)"
+        },
+        "waitBetween": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10000,
+          "description": "Delay between actions in milliseconds"
+        },
+        "validateState": {
+          "type": "boolean",
+          "description": "Validate UI state between actions (default: true)"
+        }
+      }
+    }
+  },
+  {
+    "name": "video_capture_for",
+    "description": "Record video for a fixed duration (auto-stop). Optionally enters Play Mode first.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "captureMode": {
+          "type": "string",
+          "enum": [
+            "game"
+          ],
+          "description": "Capture source. Currently only \"game\" supported."
+        },
+        "width": {
+          "type": "number",
+          "description": "Output width (0 = default 1280)"
+        },
+        "height": {
+          "type": "number",
+          "description": "Output height (0 = default 720)"
+        },
+        "fps": {
+          "type": "number",
+          "description": "Frames per second (default 30)"
+        },
+        "durationSec": {
+          "type": "number",
+          "description": "Duration to record in seconds"
+        },
+        "play": {
+          "type": "boolean",
+          "description": "Enter Play Mode before recording (default true if not already playing)"
+        }
+      },
+      "required": [
+        "durationSec"
+      ]
+    }
+  },
+  {
+    "name": "video_capture_start",
+    "description": "Start video recording (Game view). Requires com.unity.recorder.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "captureMode": {
+          "type": "string",
+          "enum": [
+            "game"
+          ],
+          "description": "Capture source. Currently only \"game\" supported."
+        },
+        "width": {
+          "type": "number",
+          "description": "Output width (0 = auto/default)"
+        },
+        "height": {
+          "type": "number",
+          "description": "Output height (0 = auto/default)"
+        },
+        "fps": {
+          "type": "number",
+          "description": "Frames per second (e.g., 30)"
+        },
+        "maxDurationSec": {
+          "type": "number",
+          "description": "Auto stop after N seconds (0 = unlimited)"
+        }
+      }
+    }
+  },
+  {
+    "name": "video_capture_status",
+    "description": "Get current video recording status.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "video_capture_stop",
+    "description": "Stop current video recording and finalize the file.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "recordingId": {
+          "type": "string",
+          "description": "Optional. Stop a specific recording session. Defaults to the latest."
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
MCPクライアントの起動シーケンス (initialize → notifications/initialized → tools/list) で、tools/list が重い初期化に巻き込まれて10秒タイムアウトしないように、tool定義を mcp-server/src/core/toolManifest.json から即時返すよう変更しました。

- tools/list: manifestを使用して即時応答
- 背景初期化: tools/list 後に開始
- ensureInitialized: 同時呼び出しの競合を抑止
