### PR TITLE
Docs: clarify terminology (avoid "CLI")

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -197,7 +197,7 @@ OpenUPMパッケージを使用するには、プロジェクトにスコープ�
 
 ```
 .unity/
-├── config.json      # ワークスペース設定
+├── cache/           # ローカルキャッシュ（Git管理外）
 └── capture/         # スクリーンショット/動画（Git管理外）
 
 UnityMCPServer/
@@ -206,7 +206,7 @@ UnityMCPServer/
 
 mcp-server/          # Node MCPサーバー
 
-csharp-lsp/          # RoslynベースLSP CLI
+csharp-lsp/          # RoslynベースLSPツール
 ```
 
 ## 機能ドキュメント

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To use OpenUPM packages, add the scoped registry to your project:
 
 ```
 .unity/
-├── config.json      # Workspace settings
+├── cache/           # Local caches (git-ignored)
 └── capture/         # Screenshots/videos (git-ignored)
 
 UnityMCPServer/
@@ -206,7 +206,7 @@ UnityMCPServer/
 
 mcp-server/          # Node MCP server
 
-csharp-lsp/          # Roslyn-based LSP CLI
+csharp-lsp/          # Roslyn-based LSP tool
 ```
 
 ## Feature Documentation

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ This document contains internal development details for Unity MCP Server maintai
 
 ## Spec Kit (SDD) Conventions
 
-This project uses Spec-Driven Development (SDD) with Spec Kit CLI v0.0.78.
+This project uses Spec-Driven Development (SDD) with Spec Kit v0.0.78.
 
 ### Directory Structure
 
@@ -36,10 +36,10 @@ specs/
 - Generated: Random 8-character hex string
 - Storage: `.specify/current-feature` tracks active feature
 
-### CLI Commands
+### Commands
 
 ```bash
-# Verify CLI and templates
+# Verify Spec Kit and templates
 uvx --from git+https://github.com/github/spec-kit.git specify check
 
 # Feature workflow


### PR DESCRIPTION
## What
- Remove/avoid "CLI" wording in repo docs where it caused confusion.
- Update repository structure snippet to reflect that `/.unity/` is fully git-ignored (no `config.json` tracked).

## Files
- README.md
- README.ja.md
- docs/development.md
