### PR TITLE
docs: READMEのスキル一覧を更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,11 +20,11 @@ Unity MCP Server は、LLMクライアントからUnity Editorを自動化しま
 
 コードインデックスツールは標準ファイル操作を上回る性能を発揮:
 
-| 操作 | コードインデックスツール | 標準ツール | 優位性 |
-|------|------------------------|------------|--------|
-| シンボル検索 | `script_symbol_find` | `grep` | **瞬時** vs 350ms |
-| 参照検索 | `script_refs_find` | `grep` | **構造化**された結果 |
-| コード検索 | `script_search` | `grep` | **3〜5倍小さい**レスポンス |
+| 操作         | コードインデックスツール | 標準ツール | 優位性                     |
+| ------------ | ------------------------ | ---------- | -------------------------- |
+| シンボル検索 | `script_symbol_find`     | `grep`     | **瞬時** vs 350ms          |
+| 参照検索     | `script_refs_find`       | `grep`     | **構造化**された結果       |
+| コード検索   | `script_search`          | `grep`     | **3〜5倍小さい**レスポンス |
 
 主な利点:
 
@@ -128,16 +128,16 @@ Unity MCP Server は **100+ ツール**を提供します。`search_tools` を�
 
 ### 利用可能なスキル
 
-| スキル | 説明 | トリガーキーワード |
-|--------|------|-------------------|
-| `mcp-server-development` | MCPサーバー（TypeScript SDK）の開発、ツール/リソース/プロンプト実装、JSON-RPCパターン | "MCPサーバー", "ツール実装", "JSON-RPC", "TypeScript" |
-| `unity-csharp-editing` | C#スクリプト編集、検索、TDDワークフローでのリファクタリング | "C#編集", "スクリプト検索", "リファクタリング" |
-| `unity-scene-management` | シーン、GameObject、コンポーネント管理 | "シーン作成", "GameObject", "コンポーネント追加" |
-| `unity-playmode-testing` | プレイモード制御、入力シミュレーション、UI自動化 | "プレイモード", "入力シミュレーション", "UIクリック" |
-| `unity-asset-management` | プレハブ、マテリアル、Addressables管理 | "プレハブ作成", "マテリアル", "Addressables" |
-| `unity-editor-imgui-design` | Unity Editor拡張向けIMGUI（EditorWindow/Inspector/PropertyDrawer）※ゲームUI用途ではない | "EditorWindow", "カスタムインスペクタ", "PropertyDrawer", "IMGUI" |
-| `unity-game-ugui-design` | ゲームUI向けuGUI（Canvas/RectTransform/Anchors）設計 | "uGUI", "Canvas", "RectTransform", "アンカー", "HUD" |
-| `unity-game-ui-toolkit-design` | ゲームUI向けUI Toolkit（UXML/USS/Flexbox）設計 | "UI Toolkit", "UXML", "USS", "VisualElement", "Flexbox" |
+| スキル                         | 説明                                                                                    | トリガーキーワード                                                |
+| ------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `mcp-server-development`       | MCPサーバー（TypeScript SDK）の開発、ツール/リソース/プロンプト実装、JSON-RPCパターン   | "MCPサーバー", "ツール実装", "JSON-RPC", "TypeScript"             |
+| `unity-csharp-editing`         | C#スクリプト編集、検索、TDDワークフローでのリファクタリング                             | "C#編集", "スクリプト検索", "リファクタリング"                    |
+| `unity-scene-management`       | シーン、GameObject、コンポーネント管理                                                  | "シーン作成", "GameObject", "コンポーネント追加"                  |
+| `unity-playmode-testing`       | プレイモード制御、入力シミュレーション、UI自動化                                        | "プレイモード", "入力シミュレーション", "UIクリック"              |
+| `unity-asset-management`       | プレハブ、マテリアル、Addressables管理                                                  | "プレハブ作成", "マテリアル", "Addressables"                      |
+| `unity-editor-imgui-design`    | Unity Editor拡張向けIMGUI（EditorWindow/Inspector/PropertyDrawer）※ゲームUI用途ではない | "EditorWindow", "カスタムインスペクタ", "PropertyDrawer", "IMGUI" |
+| `unity-game-ugui-design`       | ゲームUI向けuGUI（Canvas/RectTransform/Anchors）設計                                    | "uGUI", "Canvas", "RectTransform", "アンカー", "HUD"              |
+| `unity-game-ui-toolkit-design` | ゲームUI向けUI Toolkit（UXML/USS/Flexbox）設計                                          | "UI Toolkit", "UXML", "USS", "VisualElement", "Flexbox"           |
 
 ### インストール
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Unity MCP Server lets LLM-based clients automate the Unity Editor. It focuses on
 
 Code index tools outperform standard file operations:
 
-| Operation | Code Index Tool | Standard Tool | Advantage |
-|-----------|----------------|---------------|-----------|
-| Symbol lookup | `script_symbol_find` | `grep` | **Instant** vs 350ms |
-| Reference search | `script_refs_find` | `grep` | **Structured** results |
-| Code search | `script_search` | `grep` | **3-5x smaller** responses |
+| Operation        | Code Index Tool      | Standard Tool | Advantage                  |
+| ---------------- | -------------------- | ------------- | -------------------------- |
+| Symbol lookup    | `script_symbol_find` | `grep`        | **Instant** vs 350ms       |
+| Reference search | `script_refs_find`   | `grep`        | **Structured** results     |
+| Code search      | `script_search`      | `grep`        | **3-5x smaller** responses |
 
 Key benefits:
 
@@ -128,16 +128,16 @@ This package includes Claude Code skills that provide workflow-oriented guidance
 
 ### Available Skills
 
-| Skill | Description | Triggers |
-|-------|-------------|----------|
-| `mcp-server-development` | Build MCP servers (TypeScript SDK), implement tools/resources/prompts, JSON-RPC patterns | "MCP server", "tool handler", "JSON-RPC", "TypeScript" |
-| `unity-csharp-editing` | C# script editing, search, refactoring with TDD workflow | "C# edit", "script search", "refactoring" |
-| `unity-scene-management` | Scene, GameObject, Component management | "scene create", "GameObject", "component add" |
-| `unity-playmode-testing` | PlayMode control, input simulation, UI automation | "playmode", "input simulate", "UI click" |
-| `unity-asset-management` | Prefab, Material, Addressables management | "prefab create", "material", "Addressables" |
-| `unity-editor-imgui-design` | Unity Editor IMGUI for EditorWindow/Inspector/PropertyDrawer (not for in-game UI) | "EditorWindow", "Custom Inspector", "PropertyDrawer", "IMGUI" |
-| `unity-game-ugui-design` | In-game uGUI (Canvas/RectTransform/Anchors) UI design | "uGUI", "Canvas", "RectTransform", "Anchors", "HUD" |
-| `unity-game-ui-toolkit-design` | In-game UI Toolkit (UXML/USS/Flexbox) UI design | "UI Toolkit", "UXML", "USS", "VisualElement", "Flexbox" |
+| Skill                          | Description                                                                              | Triggers                                                      |
+| ------------------------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `mcp-server-development`       | Build MCP servers (TypeScript SDK), implement tools/resources/prompts, JSON-RPC patterns | "MCP server", "tool handler", "JSON-RPC", "TypeScript"        |
+| `unity-csharp-editing`         | C# script editing, search, refactoring with TDD workflow                                 | "C# edit", "script search", "refactoring"                     |
+| `unity-scene-management`       | Scene, GameObject, Component management                                                  | "scene create", "GameObject", "component add"                 |
+| `unity-playmode-testing`       | PlayMode control, input simulation, UI automation                                        | "playmode", "input simulate", "UI click"                      |
+| `unity-asset-management`       | Prefab, Material, Addressables management                                                | "prefab create", "material", "Addressables"                   |
+| `unity-editor-imgui-design`    | Unity Editor IMGUI for EditorWindow/Inspector/PropertyDrawer (not for in-game UI)        | "EditorWindow", "Custom Inspector", "PropertyDrawer", "IMGUI" |
+| `unity-game-ugui-design`       | In-game uGUI (Canvas/RectTransform/Anchors) UI design                                    | "uGUI", "Canvas", "RectTransform", "Anchors", "HUD"           |
+| `unity-game-ui-toolkit-design` | In-game UI Toolkit (UXML/USS/Flexbox) UI design                                          | "UI Toolkit", "UXML", "USS", "VisualElement", "Flexbox"       |
 
 ### Installation
 


### PR DESCRIPTION
- `.claude/skills` に存在する追加スキルを README に反映
- 追加: `mcp-server-development` / `unity-editor-imgui-design` / `unity-game-ugui-design` / `unity-game-ui-toolkit-design`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 利用可能なスキルセクションに新規スキルを4つ追加
  * UIデザイン関連スキルを新規追加
  * パフォーマンステーブルのヘッダーフォーマットと列幅を改善し、可読性を向上

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->