### PR TITLE
fix: Animator tool名→Unity command type を正規化

### DIFF
--- a/mcp-server/src/core/unityCommandType.js
+++ b/mcp-server/src/core/unityCommandType.js
@@ -1,0 +1,10 @@
+const TOOL_NAME_TO_UNITY_COMMAND_TYPE = Object.freeze({
+  // Animator tools: tool name (MCP) -> Unity command type (TCP)
+  analysis_animator_state_get: 'get_animator_state',
+  analysis_animator_runtime_info_get: 'get_animator_runtime_info'
+});
+
+export function normalizeUnityCommandType(type) {
+  if (typeof type !== 'string' || type.length === 0) return type;
+  return TOOL_NAME_TO_UNITY_COMMAND_TYPE[type] ?? type;
+}

--- a/mcp-server/src/core/unityConnection.js
+++ b/mcp-server/src/core/unityConnection.js
@@ -1,6 +1,7 @@
 import net from 'net';
 import { EventEmitter } from 'events';
 import { config, logger } from './config.js';
+import { normalizeUnityCommandType } from './unityCommandType.js';
 
 /**
  * Manages TCP connection to Unity Editor
@@ -360,7 +361,8 @@ export class UnityConnection extends EventEmitter {
    * @returns {Promise<any>} - Response from Unity
    */
   async sendCommand(type, params = {}) {
-    logger.info(`[Unity] enqueue sendCommand: ${type}`, { connected: this.connected });
+    const normalizedType = normalizeUnityCommandType(type);
+    logger.info(`[Unity] enqueue sendCommand: ${normalizedType}`, { connected: this.connected });
 
     if (!this.connected) {
       logger.warning('[Unity] Not connected; waiting for reconnection before sending command');
@@ -371,7 +373,7 @@ export class UnityConnection extends EventEmitter {
 
     // Create an external promise that will resolve when Unity responds
     return new Promise((outerResolve, outerReject) => {
-      const task = { type, params, outerResolve, outerReject };
+      const task = { type: normalizedType, params, outerResolve, outerReject };
       this.sendQueue.push(task);
       this._pumpQueue();
     });

--- a/mcp-server/src/tools/analysis/getAnimatorState.js
+++ b/mcp-server/src/tools/analysis/getAnimatorState.js
@@ -99,8 +99,8 @@ export async function getAnimatorStateHandler(unityConnection, args) {
       };
     }
 
-    // Send command to Unity
-    const result = await unityConnection.sendCommand('get_animator_state', args);
+    // Send command to Unity (tool name is normalized to Unity command type in UnityConnection)
+    const result = await unityConnection.sendCommand(getAnimatorStateToolDefinition.name, args);
 
     // Check for errors
     if (!result || typeof result === 'string') {
@@ -221,8 +221,11 @@ export async function getAnimatorRuntimeInfoHandler(unityConnection, args) {
       };
     }
 
-    // Send command to Unity
-    const result = await unityConnection.sendCommand('get_animator_runtime_info', args);
+    // Send command to Unity (tool name is normalized to Unity command type in UnityConnection)
+    const result = await unityConnection.sendCommand(
+      getAnimatorRuntimeInfoToolDefinition.name,
+      args
+    );
 
     // Check for errors
     if (!result || typeof result === 'string') {

--- a/mcp-server/tests/unit/handlers/analysis/GetAnimatorRuntimeInfoToolHandler.test.js
+++ b/mcp-server/tests/unit/handlers/analysis/GetAnimatorRuntimeInfoToolHandler.test.js
@@ -25,7 +25,7 @@ describe('GetAnimatorRuntimeInfoToolHandler', () => {
     assert.equal(handler.name, 'analysis_animator_runtime_info_get');
   });
 
-  it('should call get_animator_runtime_info in Unity', async () => {
+  it('should call analysis_animator_runtime_info_get command in Unity', async () => {
     const result = await handler.execute({
       gameObjectName: 'Player'
     });
@@ -33,7 +33,7 @@ describe('GetAnimatorRuntimeInfoToolHandler', () => {
     assert.equal(mockConnection.sendCommand.mock.calls.length, 1);
     assert.equal(
       mockConnection.sendCommand.mock.calls[0].arguments[0],
-      'get_animator_runtime_info'
+      'analysis_animator_runtime_info_get'
     );
 
     assert.equal(result.isError, false);

--- a/mcp-server/tests/unit/handlers/analysis/GetAnimatorStateToolHandler.test.js
+++ b/mcp-server/tests/unit/handlers/analysis/GetAnimatorStateToolHandler.test.js
@@ -89,7 +89,10 @@ describe('GetAnimatorStateToolHandler', () => {
       });
 
       assert.equal(mockConnection.sendCommand.mock.calls.length, 1);
-      assert.equal(mockConnection.sendCommand.mock.calls[0].arguments[0], 'get_animator_state');
+      assert.equal(
+        mockConnection.sendCommand.mock.calls[0].arguments[0],
+        'analysis_animator_state_get'
+      );
 
       assert.ok(result);
       assert.ok(result.content);


### PR DESCRIPTION
- `analysis_animator_state_get` / `analysis_animator_runtime_info_get` を `UnityConnection` 内で `get_animator_state` / `get_animator_runtime_info` に正規化
- Animator系ツール実装は tool名で `sendCommand` を呼ぶ形に統一（テストも更新）
- `all-tools-smoke-mcp-protocol` で Unknown command type が出ないことを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * アニメーター関連ツールの内部コマンド処理を改善し、コマンドタイプの正規化ロジックを導入しました。

* **Tests**
  * アニメーター機能のテストケースを更新し、新しいコマンド名に対応させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->