### PR TITLE
chore: glob脆弱性修正 (Dependabot alert #6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
     },
     "mcp-server": {
       "name": "@akiojin/unity-mcp-server",
-      "version": "2.42.4",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3393,15 +3393,15 @@
       "optional": true
     },
     "node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "build": "npm run build --workspaces --if-present",
     "release": "echo \"Release is handled by GitHub Actions (release-please).\" && exit 1"
   },
+  "overrides": {
+    "markdownlint-cli": {
+      "glob": "11.1.0"
+    }
+  },
   "workspaces": [
     "mcp-server",
     "packages/fast-sql"


### PR DESCRIPTION
- Dependabot alert #6 (GHSA-5j98-mcp5-4vw2 / CVE-2025-64756) 対応\n- markdownlint-cli の依存する glob を 11.1.0 に更新（command injection 修正）\n- npm overrides を追加して lockfile を更新\n\n検証: npm run test:ci --workspace=mcp-server