### PR TITLE
docs: スキル/テスト計画のツール名を新命名へ統一

### DIFF
--- a/.claude-plugin/skills/mcp-server-development/SKILL.md
+++ b/.claude-plugin/skills/mcp-server-development/SKILL.md
@@ -28,7 +28,7 @@ MCP servers bridge AI assistants to external systems. They must be:
 export class SystemPingToolHandler extends BaseToolHandler {
   constructor(unityConnection) {
     super({
-      name: 'system_ping',
+      name: 'ping',
       description: 'Check Unity Editor connectivity',
       inputSchema: { type: 'object', properties: {} }
     });
@@ -130,7 +130,7 @@ Unity communication uses a simple request/response pattern:
 
 ```javascript
 const result = await this.unityConnection.send({
-  command: 'gameobject_create',
+  command: 'create_gameobject',
   params: { name: 'Cube', primitiveType: 'cube' }
 });
 ```
@@ -142,7 +142,7 @@ const result = await this.unityConnection.send({
 ```javascript
 execute(params) {
   return this.unityConnection.send({
-    command: 'screenshot_capture',
+    command: 'capture_screenshot',
     workspaceRoot: config.workspaceRoot,
     ...params
   });

--- a/.claude-plugin/skills/unity-asset-management/SKILL.md
+++ b/.claude-plugin/skills/unity-asset-management/SKILL.md
@@ -14,13 +14,13 @@ allowed-tools: Read, Grep, Glob
 
 ```javascript
 // GameObjectからプレハブ作成
-mcp__unity-mcp-server__asset_prefab_create({
+mcp__unity-mcp-server__create_prefab({
   prefabPath: "Assets/Prefabs/Enemy.prefab",
   gameObjectPath: "/Enemy"
 })
 
 // プレハブをシーンにインスタンス化
-mcp__unity-mcp-server__asset_prefab_instantiate({
+mcp__unity-mcp-server__instantiate_prefab({
   prefabPath: "Assets/Prefabs/Enemy.prefab",
   position: { x: 5, y: 0, z: 0 },
   name: "Enemy_01"
@@ -31,7 +31,7 @@ mcp__unity-mcp-server__asset_prefab_instantiate({
 
 ```javascript
 // 基本マテリアル作成
-mcp__unity-mcp-server__asset_material_create({
+mcp__unity-mcp-server__create_material({
   materialPath: "Assets/Materials/RedMetal.mat",
   shader: "Standard",
   properties: {
@@ -46,7 +46,7 @@ mcp__unity-mcp-server__asset_material_create({
 
 ```javascript
 // テクスチャを検索
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "find_assets",
   filter: "t:Texture2D"
 })
@@ -58,19 +58,19 @@ mcp__unity-mcp-server__asset_database_manage({
 
 ```javascript
 // シーンのGameObjectからプレハブ作成
-mcp__unity-mcp-server__asset_prefab_create({
+mcp__unity-mcp-server__create_prefab({
   prefabPath: "Assets/Prefabs/Player.prefab",
   gameObjectPath: "/Player"
 })
 
 // 空のプレハブを作成
-mcp__unity-mcp-server__asset_prefab_create({
+mcp__unity-mcp-server__create_prefab({
   prefabPath: "Assets/Prefabs/Empty.prefab",
   createFromTemplate: true
 })
 
 // 上書き許可
-mcp__unity-mcp-server__asset_prefab_create({
+mcp__unity-mcp-server__create_prefab({
   prefabPath: "Assets/Prefabs/Player.prefab",
   gameObjectPath: "/Player",
   overwrite: true
@@ -81,41 +81,41 @@ mcp__unity-mcp-server__asset_prefab_create({
 
 ```javascript
 // プレハブを開く
-mcp__unity-mcp-server__asset_prefab_open({
+mcp__unity-mcp-server__open_prefab({
   prefabPath: "Assets/Prefabs/Player.prefab"
 })
 
 // 特定のオブジェクトにフォーカス
-mcp__unity-mcp-server__asset_prefab_open({
+mcp__unity-mcp-server__open_prefab({
   prefabPath: "Assets/Prefabs/Player.prefab",
   focusObject: "Weapon",  // プレハブルート相対パス
   isolateObject: true
 })
 
 // プレハブモード中の編集（コンポーネント操作等）
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Player",  // プレハブモード中はプレハブルートがルート
   componentType: "AudioSource"
 })
 
 // 保存してプレハブモード終了
-mcp__unity-mcp-server__asset_prefab_save()
-mcp__unity-mcp-server__asset_prefab_exit_mode({ saveChanges: true })
+mcp__unity-mcp-server__save_prefab()
+mcp__unity-mcp-server__exit_prefab_mode({ saveChanges: true })
 
 // 保存せずに終了
-mcp__unity-mcp-server__asset_prefab_exit_mode({ saveChanges: false })
+mcp__unity-mcp-server__exit_prefab_mode({ saveChanges: false })
 ```
 
 ### プレハブインスタンス化
 
 ```javascript
 // 基本インスタンス化
-mcp__unity-mcp-server__asset_prefab_instantiate({
+mcp__unity-mcp-server__instantiate_prefab({
   prefabPath: "Assets/Prefabs/Enemy.prefab"
 })
 
 // Transform指定
-mcp__unity-mcp-server__asset_prefab_instantiate({
+mcp__unity-mcp-server__instantiate_prefab({
   prefabPath: "Assets/Prefabs/Enemy.prefab",
   position: { x: 10, y: 0, z: 5 },
   rotation: { x: 0, y: 90, z: 0 },
@@ -123,7 +123,7 @@ mcp__unity-mcp-server__asset_prefab_instantiate({
 })
 
 // 親オブジェクト指定
-mcp__unity-mcp-server__asset_prefab_instantiate({
+mcp__unity-mcp-server__instantiate_prefab({
   prefabPath: "Assets/Prefabs/Coin.prefab",
   parent: "/Collectibles",
   position: { x: 0, y: 1, z: 0 }
@@ -134,7 +134,7 @@ mcp__unity-mcp-server__asset_prefab_instantiate({
 
 ```javascript
 // プロパティ変更（インスタンスにも適用）
-mcp__unity-mcp-server__asset_prefab_modify({
+mcp__unity-mcp-server__modify_prefab({
   prefabPath: "Assets/Prefabs/Enemy.prefab",
   modifications: {
     "health": 150,
@@ -144,7 +144,7 @@ mcp__unity-mcp-server__asset_prefab_modify({
 })
 
 // インスタンスには適用しない
-mcp__unity-mcp-server__asset_prefab_modify({
+mcp__unity-mcp-server__modify_prefab({
   prefabPath: "Assets/Prefabs/Enemy.prefab",
   modifications: { "debugMode": true },
   applyToInstances: false
@@ -157,7 +157,7 @@ mcp__unity-mcp-server__asset_prefab_modify({
 
 ```javascript
 // Standardシェーダー
-mcp__unity-mcp-server__asset_material_create({
+mcp__unity-mcp-server__create_material({
   materialPath: "Assets/Materials/Metal.mat",
   shader: "Standard",
   properties: {
@@ -168,7 +168,7 @@ mcp__unity-mcp-server__asset_material_create({
 })
 
 // Unlitシェーダー
-mcp__unity-mcp-server__asset_material_create({
+mcp__unity-mcp-server__create_material({
   materialPath: "Assets/Materials/Unlit.mat",
   shader: "Unlit/Color",
   properties: {
@@ -177,7 +177,7 @@ mcp__unity-mcp-server__asset_material_create({
 })
 
 // URPシェーダー
-mcp__unity-mcp-server__asset_material_create({
+mcp__unity-mcp-server__create_material({
   materialPath: "Assets/Materials/URPLit.mat",
   shader: "Universal Render Pipeline/Lit",
   properties: {
@@ -187,7 +187,7 @@ mcp__unity-mcp-server__asset_material_create({
 })
 
 // 既存マテリアルをコピー
-mcp__unity-mcp-server__asset_material_create({
+mcp__unity-mcp-server__create_material({
   materialPath: "Assets/Materials/MetalRed.mat",
   copyFrom: "Assets/Materials/Metal.mat",
   properties: {
@@ -200,7 +200,7 @@ mcp__unity-mcp-server__asset_material_create({
 
 ```javascript
 // プロパティ変更
-mcp__unity-mcp-server__asset_material_modify({
+mcp__unity-mcp-server__modify_material({
   materialPath: "Assets/Materials/Metal.mat",
   properties: {
     "_Color": [0, 0, 1, 1],
@@ -209,7 +209,7 @@ mcp__unity-mcp-server__asset_material_modify({
 })
 
 // シェーダー変更
-mcp__unity-mcp-server__asset_material_modify({
+mcp__unity-mcp-server__modify_material({
   materialPath: "Assets/Materials/Debug.mat",
   shader: "Unlit/Color",
   properties: {
@@ -238,31 +238,31 @@ mcp__unity-mcp-server__asset_material_modify({
 
 ```javascript
 // 型フィルタ
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "find_assets",
   filter: "t:Texture2D"
 })
 
 // 名前フィルタ
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "find_assets",
   filter: "Player"
 })
 
 // ラベルフィルタ
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "find_assets",
   filter: "l:UI"
 })
 
 // 複合フィルタ
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "find_assets",
   filter: "t:Material Player"
 })
 
 // フォルダ指定
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "find_assets",
   filter: "t:Prefab",
   searchInFolders: ["Assets/Prefabs", "Assets/Characters"]
@@ -281,7 +281,7 @@ mcp__unity-mcp-server__asset_database_manage({
 ### アセット情報取得
 
 ```javascript
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "get_asset_info",
   assetPath: "Assets/Textures/Player.png"
 })
@@ -292,7 +292,7 @@ mcp__unity-mcp-server__asset_database_manage({
 
 ```javascript
 // フォルダ作成
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "create_folder",
   folderPath: "Assets/NewFeature/Prefabs"
 })
@@ -302,21 +302,21 @@ mcp__unity-mcp-server__asset_database_manage({
 
 ```javascript
 // 移動
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "move_asset",
   fromPath: "Assets/Old/Player.prefab",
   toPath: "Assets/New/Player.prefab"
 })
 
 // コピー
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "copy_asset",
   fromPath: "Assets/Templates/Enemy.prefab",
   toPath: "Assets/Enemies/Enemy_01.prefab"
 })
 
 // 削除
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "delete_asset",
   assetPath: "Assets/Unused/OldPrefab.prefab"
 })
@@ -326,12 +326,12 @@ mcp__unity-mcp-server__asset_database_manage({
 
 ```javascript
 // アセットデータベースをリフレッシュ
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "refresh"
 })
 
 // 全アセットを保存
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "save"
 })
 ```
@@ -342,7 +342,7 @@ mcp__unity-mcp-server__asset_database_manage({
 
 ```javascript
 // アセットの依存先を取得
-mcp__unity-mcp-server__asset_dependency_analyze({
+mcp__unity-mcp-server__analyze_asset_dependencies({
   action: "get_dependencies",
   assetPath: "Assets/Prefabs/Player.prefab",
   recursive: true  // 間接依存も含む
@@ -353,7 +353,7 @@ mcp__unity-mcp-server__asset_dependency_analyze({
 
 ```javascript
 // このアセットを参照しているアセットを検索
-mcp__unity-mcp-server__asset_dependency_analyze({
+mcp__unity-mcp-server__analyze_asset_dependencies({
   action: "get_dependents",
   assetPath: "Assets/Materials/PlayerMat.mat"
 })
@@ -362,7 +362,7 @@ mcp__unity-mcp-server__asset_dependency_analyze({
 ### 循環依存検出
 
 ```javascript
-mcp__unity-mcp-server__asset_dependency_analyze({
+mcp__unity-mcp-server__analyze_asset_dependencies({
   action: "analyze_circular"
 })
 ```
@@ -370,7 +370,7 @@ mcp__unity-mcp-server__asset_dependency_analyze({
 ### 未使用アセット検出
 
 ```javascript
-mcp__unity-mcp-server__asset_dependency_analyze({
+mcp__unity-mcp-server__analyze_asset_dependencies({
   action: "find_unused",
   includeBuiltIn: false
 })
@@ -380,7 +380,7 @@ mcp__unity-mcp-server__asset_dependency_analyze({
 
 ```javascript
 // アセットとその依存関係の合計サイズ
-mcp__unity-mcp-server__asset_dependency_analyze({
+mcp__unity-mcp-server__analyze_asset_dependencies({
   action: "analyze_size_impact",
   assetPath: "Assets/Prefabs/Boss.prefab"
 })
@@ -390,7 +390,7 @@ mcp__unity-mcp-server__asset_dependency_analyze({
 
 ```javascript
 // 壊れた参照を検出
-mcp__unity-mcp-server__asset_dependency_analyze({
+mcp__unity-mcp-server__analyze_asset_dependencies({
   action: "validate_references"
 })
 ```
@@ -515,7 +515,7 @@ mcp__unity-mcp-server__addressables_analyze({
 ### インポート設定取得
 
 ```javascript
-mcp__unity-mcp-server__asset_import_settings_manage({
+mcp__unity-mcp-server__manage_asset_import_settings({
   action: "get",
   assetPath: "Assets/Textures/Player.png"
 })
@@ -524,7 +524,7 @@ mcp__unity-mcp-server__asset_import_settings_manage({
 ### テクスチャ設定
 
 ```javascript
-mcp__unity-mcp-server__asset_import_settings_manage({
+mcp__unity-mcp-server__manage_asset_import_settings({
   action: "modify",
   assetPath: "Assets/Textures/Player.png",
   settings: {
@@ -540,7 +540,7 @@ mcp__unity-mcp-server__asset_import_settings_manage({
 ### オーディオ設定
 
 ```javascript
-mcp__unity-mcp-server__asset_import_settings_manage({
+mcp__unity-mcp-server__manage_asset_import_settings({
   action: "modify",
   assetPath: "Assets/Audio/BGM.mp3",
   settings: {
@@ -556,7 +556,7 @@ mcp__unity-mcp-server__asset_import_settings_manage({
 
 ```javascript
 // 保存済みプリセットを適用
-mcp__unity-mcp-server__asset_import_settings_manage({
+mcp__unity-mcp-server__manage_asset_import_settings({
   action: "apply_preset",
   assetPath: "Assets/Textures/UI_Icon.png",
   preset: "UISprite"
@@ -566,7 +566,7 @@ mcp__unity-mcp-server__asset_import_settings_manage({
 ### 再インポート
 
 ```javascript
-mcp__unity-mcp-server__asset_import_settings_manage({
+mcp__unity-mcp-server__manage_asset_import_settings({
   action: "reimport",
   assetPath: "Assets/Textures/Player.png"
 })
@@ -578,29 +578,29 @@ mcp__unity-mcp-server__asset_import_settings_manage({
 
 ```javascript
 // 1. シーンでGameObjectを構築
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "NewEnemy",
   primitiveType: "capsule"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/NewEnemy",
   componentType: "Rigidbody"
 })
 
 // 2. プレハブ化
-mcp__unity-mcp-server__asset_prefab_create({
+mcp__unity-mcp-server__create_prefab({
   prefabPath: "Assets/Prefabs/Enemies/NewEnemy.prefab",
   gameObjectPath: "/NewEnemy"
 })
 
 // 3. シーンのオリジナルを削除
-mcp__unity-mcp-server__gameobject_delete({
+mcp__unity-mcp-server__delete_gameobject({
   path: "/NewEnemy"
 })
 
 // 4. プレハブからインスタンス化
-mcp__unity-mcp-server__asset_prefab_instantiate({
+mcp__unity-mcp-server__instantiate_prefab({
   prefabPath: "Assets/Prefabs/Enemies/NewEnemy.prefab",
   position: { x: 0, y: 0, z: 0 }
 })
@@ -610,7 +610,7 @@ mcp__unity-mcp-server__asset_prefab_instantiate({
 
 ```javascript
 // ベースマテリアル作成
-mcp__unity-mcp-server__asset_material_create({
+mcp__unity-mcp-server__create_material({
   materialPath: "Assets/Materials/Enemy_Base.mat",
   shader: "Standard",
   properties: {
@@ -627,7 +627,7 @@ const colors = [
 ]
 
 for (const variant of colors) {
-  mcp__unity-mcp-server__asset_material_create({
+  mcp__unity-mcp-server__create_material({
     materialPath: `Assets/Materials/Enemy_${variant.name}.mat`,
     copyFrom: "Assets/Materials/Enemy_Base.mat",
     properties: { "_Color": variant.color }
@@ -704,9 +704,9 @@ materialPath: "Assets/Materials/Red.mat"
 
 ```javascript
 // ✅ 必ずプレハブモードを終了
-mcp__unity-mcp-server__asset_prefab_open({ prefabPath: "..." })
+mcp__unity-mcp-server__open_prefab({ prefabPath: "..." })
 // ... 編集 ...
-mcp__unity-mcp-server__asset_prefab_exit_mode({ saveChanges: true })
+mcp__unity-mcp-server__exit_prefab_mode({ saveChanges: true })
 ```
 
 ### 4. リフレッシュ忘れ
@@ -714,7 +714,7 @@ mcp__unity-mcp-server__asset_prefab_exit_mode({ saveChanges: true })
 ```javascript
 // 外部でファイルを変更した後
 // ✅ リフレッシュで変更を反映
-mcp__unity-mcp-server__asset_database_manage({
+mcp__unity-mcp-server__manage_asset_database({
   action: "refresh"
 })
 ```
@@ -746,17 +746,17 @@ mcp__unity-mcp-server__addressables_manage({
 
 | ツール | 用途 |
 |--------|------|
-| `asset_prefab_create` | プレハブ作成 |
-| `asset_prefab_open` | プレハブモード開始 |
-| `asset_prefab_exit_mode` | プレハブモード終了 |
-| `asset_prefab_save` | プレハブ保存 |
-| `asset_prefab_instantiate` | プレハブ配置 |
-| `asset_prefab_modify` | プレハブ修正 |
-| `asset_material_create` | マテリアル作成 |
-| `asset_material_modify` | マテリアル修正 |
-| `asset_database_manage` | アセットDB操作 |
-| `asset_dependency_analyze` | 依存関係分析 |
-| `asset_import_settings_manage` | インポート設定 |
+| `create_prefab` | プレハブ作成 |
+| `open_prefab` | プレハブモード開始 |
+| `exit_prefab_mode` | プレハブモード終了 |
+| `save_prefab` | プレハブ保存 |
+| `instantiate_prefab` | プレハブ配置 |
+| `modify_prefab` | プレハブ修正 |
+| `create_material` | マテリアル作成 |
+| `modify_material` | マテリアル修正 |
+| `manage_asset_database` | アセットDB操作 |
+| `analyze_asset_dependencies` | 依存関係分析 |
+| `manage_asset_import_settings` | インポート設定 |
 | `addressables_manage` | Addressables管理 |
 | `addressables_build` | Addressablesビルド |
 | `addressables_analyze` | Addressables分析 |

--- a/.claude-plugin/skills/unity-csharp-editing/SKILL.md
+++ b/.claude-plugin/skills/unity-csharp-editing/SKILL.md
@@ -210,7 +210,7 @@ mcp__unity-mcp-server__script_edit_structured({
 
 ```javascript
 // コンパイル状態を確認
-mcp__unity-mcp-server__compilation_get_state({ includeMessages: true })
+mcp__unity-mcp-server__get_compilation_state({ includeMessages: true })
 
 // 影響範囲を確認してからリファクタリング
 mcp__unity-mcp-server__script_refs_find({
@@ -442,4 +442,4 @@ mcp__unity-mcp-server__code_index_update({
 | `code_index_status` | インデックス状態確認 | - |
 | `code_index_build` | インデックス構築 | - |
 | `code_index_update` | インデックス更新 | paths |
-| `compilation_get_state` | コンパイル状態 | includeMessages |
+| `get_compilation_state` | コンパイル状態 | includeMessages |

--- a/.claude-plugin/skills/unity-editor-imgui-design/SKILL.md
+++ b/.claude-plugin/skills/unity-editor-imgui-design/SKILL.md
@@ -9,9 +9,9 @@ allowed-tools:
   - mcp__unity-mcp-server__script_search
   - mcp__unity-mcp-server__script_symbols_get
   - mcp__unity-mcp-server__script_symbol_find
-  - mcp__unity-mcp-server__asset_database_manage
-  - mcp__unity-mcp-server__menu_item_execute
-  - mcp__unity-mcp-server__compilation_get_state
+  - mcp__unity-mcp-server__manage_asset_database
+  - mcp__unity-mcp-server__execute_menu_item
+  - mcp__unity-mcp-server__get_compilation_state
 ---
 
 # Unity Editor IMGUI Design Skill

--- a/.claude-plugin/skills/unity-game-ugui-design/SKILL.md
+++ b/.claude-plugin/skills/unity-game-ugui-design/SKILL.md
@@ -2,20 +2,20 @@
 name: unity-game-ugui-design
 description: UnityのuGUI（Canvas/RectTransform/Anchors）を使用したゲームUIデザイン。HUD、ヘルスバー、インベントリ、スキルバー等のゲームUI要素、モバイルレスポンシブ対応、Safe Area対応を含む。使用タイミング: ゲームUI設計、HUD作成、Canvas設定、モバイルUI、Anchors設定
 allowed-tools:
-  - mcp__unity-mcp-server__ui_find_elements
-  - mcp__unity-mcp-server__ui_click_element
-  - mcp__unity-mcp-server__ui_get_element_state
-  - mcp__unity-mcp-server__ui_set_element_value
-  - mcp__unity-mcp-server__ui_simulate_input
-  - mcp__unity-mcp-server__component_add
-  - mcp__unity-mcp-server__component_modify
-  - mcp__unity-mcp-server__component_field_set
-  - mcp__unity-mcp-server__component_list
-  - mcp__unity-mcp-server__component_get_types
-  - mcp__unity-mcp-server__gameobject_create
-  - mcp__unity-mcp-server__gameobject_modify
-  - mcp__unity-mcp-server__gameobject_find
-  - mcp__unity-mcp-server__gameobject_get_hierarchy
+  - mcp__unity-mcp-server__find_ui_elements
+  - mcp__unity-mcp-server__click_ui_element
+  - mcp__unity-mcp-server__get_ui_element_state
+  - mcp__unity-mcp-server__set_ui_element_value
+  - mcp__unity-mcp-server__simulate_ui_input
+  - mcp__unity-mcp-server__add_component
+  - mcp__unity-mcp-server__modify_component
+  - mcp__unity-mcp-server__set_component_field
+  - mcp__unity-mcp-server__list_components
+  - mcp__unity-mcp-server__get_component_types
+  - mcp__unity-mcp-server__create_gameobject
+  - mcp__unity-mcp-server__modify_gameobject
+  - mcp__unity-mcp-server__find_gameobject
+  - mcp__unity-mcp-server__get_hierarchy
   - mcp__unity-mcp-server__script_edit_structured
   - mcp__unity-mcp-server__script_create_class
   - mcp__unity-mcp-server__script_read
@@ -32,12 +32,12 @@ UnityのuGUI（Unity GUI）システムを使用したゲームUIデザインの
 
 ```javascript
 // 1. Canvasを作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Canvas"
 })
 
 // 2. Canvasコンポーネントを追加
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas",
   componentType: "Canvas",
   properties: {
@@ -46,7 +46,7 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 3. CanvasScalerを追加（レスポンシブ対応）
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler",
   properties: {
@@ -58,7 +58,7 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 4. GraphicRaycasterを追加（インタラクション用）
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas",
   componentType: "GraphicRaycaster"
 })
@@ -78,13 +78,13 @@ mcp__unity-mcp-server__component_add({
 
 ```javascript
 // ワールドスペースCanvas（敵頭上HPバー）
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Enemy/HealthCanvas",
   componentType: "Canvas",
   properties: { renderMode: 2 }  // WorldSpace
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Enemy/HealthCanvas",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -102,7 +102,7 @@ mcp__unity-mcp-server__component_field_set({
 
 ```javascript
 // HUD用オーバーレイCanvas
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas",
   componentType: "Canvas",
   properties: { renderMode: 0 }  // ScreenSpaceOverlay
@@ -119,14 +119,14 @@ mcp__unity-mcp-server__component_add({
 
 ```javascript
 // ビルボードマーカー
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/QuestMarker/Canvas",
   componentType: "Canvas",
   properties: { renderMode: 2 }  // WorldSpace
 })
 
 // ビルボードスクリプト追加
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/QuestMarker/Canvas",
   componentType: "BillboardUI"
 })
@@ -142,7 +142,7 @@ mcp__unity-mcp-server__component_add({
 
 ```javascript
 // 被ダメージフラッシュ用Canvas
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/EffectCanvas",
   componentType: "Canvas",
   properties: {
@@ -152,12 +152,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // フラッシュImage（全画面）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "DamageFlash",
   parentPath: "/EffectCanvas"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/EffectCanvas/DamageFlash",
   componentType: "Image",
   properties: {
@@ -209,33 +209,33 @@ mcp__unity-mcp-server__component_add({
 
 ```javascript
 // HP バー（左上配置）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "HPBar",
   parentPath: "/HUDCanvas/SafeArea"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/HPBar",
   componentType: "RectTransform",
   fieldPath: "anchorMin",
   value: { x: 0, y: 1 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/HPBar",
   componentType: "RectTransform",
   fieldPath: "anchorMax",
   value: { x: 0, y: 1 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/HPBar",
   componentType: "RectTransform",
   fieldPath: "pivot",
   value: { x: 0, y: 1 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/HPBar",
   componentType: "RectTransform",
   fieldPath: "anchoredPosition",
@@ -243,33 +243,33 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // ミニマップ（右上配置）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Minimap",
   parentPath: "/HUDCanvas/SafeArea"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/Minimap",
   componentType: "RectTransform",
   fieldPath: "anchorMin",
   value: { x: 1, y: 1 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/Minimap",
   componentType: "RectTransform",
   fieldPath: "anchorMax",
   value: { x: 1, y: 1 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/Minimap",
   componentType: "RectTransform",
   fieldPath: "pivot",
   value: { x: 1, y: 1 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/Minimap",
   componentType: "RectTransform",
   fieldPath: "anchoredPosition",
@@ -277,33 +277,33 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // スキルバー（下部中央配置）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "SkillBar",
   parentPath: "/HUDCanvas/SafeArea"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar",
   componentType: "RectTransform",
   fieldPath: "anchorMin",
   value: { x: 0.5, y: 0 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar",
   componentType: "RectTransform",
   fieldPath: "anchorMax",
   value: { x: 0.5, y: 0 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar",
   componentType: "RectTransform",
   fieldPath: "pivot",
   value: { x: 0.5, y: 0 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar",
   componentType: "RectTransform",
   fieldPath: "anchoredPosition",
@@ -333,12 +333,12 @@ HealthBar (RectTransform)
 
 ```javascript
 // ヘルスバー作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "HealthBar",
   parentPath: "/HUDCanvas/SafeArea"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/HealthBar",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -346,12 +346,12 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // 背景
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Background",
   parentPath: "/HUDCanvas/SafeArea/HealthBar"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/HealthBar/Background",
   componentType: "Image",
   properties: {
@@ -360,12 +360,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 遅延ゲージ（Filled Image）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "DelayedFill",
   parentPath: "/HUDCanvas/SafeArea/HealthBar"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/HealthBar/DelayedFill",
   componentType: "Image",
   properties: {
@@ -377,12 +377,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 現在値ゲージ
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Fill",
   parentPath: "/HUDCanvas/SafeArea/HealthBar"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/HealthBar/Fill",
   componentType: "Image",
   properties: {
@@ -394,12 +394,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // テキスト
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Text",
   parentPath: "/HUDCanvas/SafeArea/HealthBar"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/HealthBar/Text",
   componentType: "TextMeshProUGUI",
   properties: {
@@ -484,12 +484,12 @@ SkillSlot (RectTransform)
 
 ```javascript
 // スキルスロット作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "SkillSlot",
   parentPath: "/HUDCanvas/SafeArea/SkillBar"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -497,23 +497,23 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // アイコン
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Icon",
   parentPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot/Icon",
   componentType: "Image"
 })
 
 // クールダウンオーバーレイ（Radial Fill）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "CooldownOverlay",
   parentPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot/CooldownOverlay",
   componentType: "Image",
   properties: {
@@ -527,12 +527,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // クールダウンテキスト
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "CooldownText",
   parentPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot/CooldownText",
   componentType: "TextMeshProUGUI",
   properties: {
@@ -544,12 +544,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // キーヒント
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "KeyHint",
   parentPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/SkillBar/SkillSlot/KeyHint",
   componentType: "TextMeshProUGUI",
   properties: {
@@ -634,12 +634,12 @@ InventoryGrid (RectTransform + GridLayoutGroup)
 
 ```javascript
 // インベントリグリッド作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "InventoryGrid",
   parentPath: "/InventoryCanvas/Panel"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/InventoryCanvas/Panel/InventoryGrid",
   componentType: "GridLayoutGroup",
   properties: {
@@ -654,12 +654,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // アイテムスロット作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "ItemSlot",
   parentPath: "/InventoryCanvas/Panel/InventoryGrid"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -667,12 +667,12 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // 背景（レアリティ枠）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Background",
   parentPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot/Background",
   componentType: "Image",
   properties: {
@@ -681,23 +681,23 @@ mcp__unity-mcp-server__component_add({
 })
 
 // アイコン
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Icon",
   parentPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot/Icon",
   componentType: "Image"
 })
 
 // スタック数
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "StackCount",
   parentPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot/StackCount",
   componentType: "TextMeshProUGUI",
   properties: {
@@ -708,12 +708,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 選択ハイライト
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "SelectionHighlight",
   parentPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/InventoryCanvas/Panel/InventoryGrid/ItemSlot/SelectionHighlight",
   componentType: "Image",
   properties: {
@@ -769,12 +769,12 @@ DamageNumber (RectTransform)
 
 ```javascript
 // ダメージ数値Prefab作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "DamageNumber",
   parentPath: "/WorldCanvas"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/WorldCanvas/DamageNumber",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -782,12 +782,12 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // テキスト
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Text",
   parentPath: "/WorldCanvas/DamageNumber"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/WorldCanvas/DamageNumber/Text",
   componentType: "TextMeshProUGUI",
   properties: {
@@ -876,12 +876,12 @@ MinimapContainer (RectTransform)
 
 ```javascript
 // ミニマップコンテナ
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "MinimapContainer",
   parentPath: "/HUDCanvas/SafeArea"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/MinimapContainer",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -889,18 +889,18 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // マップ表示（RawImage）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "MapImage",
   parentPath: "/HUDCanvas/SafeArea/MinimapContainer"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/MinimapContainer/MapImage",
   componentType: "RawImage"
 })
 
 // 円形マスク用
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/MinimapContainer/MapImage",
   componentType: "Mask",
   properties: {
@@ -909,17 +909,17 @@ mcp__unity-mcp-server__component_add({
 })
 
 // プレイヤーアイコン（中央固定）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "PlayerIcon",
   parentPath: "/HUDCanvas/SafeArea/MinimapContainer"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/MinimapContainer/PlayerIcon",
   componentType: "Image"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/HUDCanvas/SafeArea/MinimapContainer/PlayerIcon",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -927,12 +927,12 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // 枠
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Border",
   parentPath: "/HUDCanvas/SafeArea/MinimapContainer"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/HUDCanvas/SafeArea/MinimapContainer/Border",
   componentType: "Image",
   properties: {
@@ -963,12 +963,12 @@ DialogPanel (RectTransform + CanvasGroup)
 
 ```javascript
 // ダイアログパネル
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "DialogPanel",
   parentPath: "/DialogCanvas"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/DialogCanvas/DialogPanel",
   componentType: "Image",
   properties: {
@@ -976,20 +976,20 @@ mcp__unity-mcp-server__component_add({
   }
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/DialogCanvas/DialogPanel",
   componentType: "CanvasGroup"
 })
 
 // 下部ストレッチ配置
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/DialogCanvas/DialogPanel",
   componentType: "RectTransform",
   fieldPath: "anchorMin",
   value: { x: 0, y: 0 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/DialogCanvas/DialogPanel",
   componentType: "RectTransform",
   fieldPath: "anchorMax",
@@ -997,12 +997,12 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // 話者名
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "SpeakerName",
   parentPath: "/DialogCanvas/DialogPanel"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/DialogCanvas/DialogPanel/SpeakerName",
   componentType: "TextMeshProUGUI",
   properties: {
@@ -1014,17 +1014,17 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 顔アイコン
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Portrait",
   parentPath: "/DialogCanvas/DialogPanel"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/DialogCanvas/DialogPanel/Portrait",
   componentType: "Image"
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/DialogCanvas/DialogPanel/Portrait",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -1032,12 +1032,12 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // ダイアログテキスト
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "DialogText",
   parentPath: "/DialogCanvas/DialogPanel"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/DialogCanvas/DialogPanel/DialogText",
   componentType: "TextMeshProUGUI",
   properties: {
@@ -1048,12 +1048,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 選択肢コンテナ
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "ChoicesContainer",
   parentPath: "/DialogCanvas/DialogPanel"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/DialogCanvas/DialogPanel/ChoicesContainer",
   componentType: "VerticalLayoutGroup",
   properties: {
@@ -1063,12 +1063,12 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 次へインジケーター
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "ContinueIndicator",
   parentPath: "/DialogCanvas/DialogPanel"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/DialogCanvas/DialogPanel/ContinueIndicator",
   componentType: "Image"
 })
@@ -1155,14 +1155,14 @@ RectTransformはUI要素の位置・サイズを制御するコンポーネン�
 
 ```javascript
 // RectTransformの主要プロパティ
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/Button",
   componentType: "RectTransform",
   fieldPath: "anchoredPosition",
   value: { x: 0, y: 100 }  // アンカー基準の位置
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/Button",
   componentType: "RectTransform",
   fieldPath: "sizeDelta",
@@ -1190,28 +1190,28 @@ mcp__unity-mcp-server__component_field_set({
 
 ```javascript
 // 全画面ストレッチの例
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/Background",
   componentType: "RectTransform",
   fieldPath: "anchorMin",
   value: { x: 0, y: 0 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/Background",
   componentType: "RectTransform",
   fieldPath: "anchorMax",
   value: { x: 1, y: 1 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/Background",
   componentType: "RectTransform",
   fieldPath: "offsetMin",
   value: { x: 0, y: 0 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/Background",
   componentType: "RectTransform",
   fieldPath: "offsetMax",
@@ -1228,21 +1228,21 @@ mcp__unity-mcp-server__component_field_set({
 #### 縦向き（Portrait）優先
 
 ```javascript
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler",
   fieldPath: "uiScaleMode",
   value: 1  // ScaleWithScreenSize
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler",
   fieldPath: "referenceResolution",
   value: { x: 1080, y: 1920 }  // 9:16 縦向き基準
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler",
   fieldPath: "matchWidthOrHeight",
@@ -1253,14 +1253,14 @@ mcp__unity-mcp-server__component_field_set({
 #### 横向き（Landscape）優先
 
 ```javascript
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler",
   fieldPath: "referenceResolution",
   value: { x: 1920, y: 1080 }  // 16:9 横向き基準
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler",
   fieldPath: "matchWidthOrHeight",
@@ -1354,25 +1354,25 @@ public class SafeAreaHandler : MonoBehaviour
 
 ```javascript
 // Safe Area用パネルを作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "SafeAreaPanel",
   parentPath: "/Canvas"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/SafeAreaPanel",
   componentType: "RectTransform"
 })
 
 // 全画面ストレッチに設定
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/SafeAreaPanel",
   componentType: "RectTransform",
   fieldPath: "anchorMin",
   value: { x: 0, y: 0 }
 })
 
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/SafeAreaPanel",
   componentType: "RectTransform",
   fieldPath: "anchorMax",
@@ -1380,7 +1380,7 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // SafeAreaHandlerスクリプトを追加
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/SafeAreaPanel",
   componentType: "SafeAreaHandler"
 })
@@ -1393,7 +1393,7 @@ mcp__unity-mcp-server__component_add({
 ### Horizontal Layout Group
 
 ```javascript
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/ButtonContainer",
   componentType: "HorizontalLayoutGroup",
   properties: {
@@ -1410,7 +1410,7 @@ mcp__unity-mcp-server__component_add({
 ### Vertical Layout Group
 
 ```javascript
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/MenuList",
   componentType: "VerticalLayoutGroup",
   properties: {
@@ -1424,7 +1424,7 @@ mcp__unity-mcp-server__component_add({
 ### Grid Layout Group
 
 ```javascript
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/ItemGrid",
   componentType: "GridLayoutGroup",
   properties: {
@@ -1444,7 +1444,7 @@ mcp__unity-mcp-server__component_add({
 子要素のサイズに合わせて親を自動調整します。
 
 ```javascript
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/AutoSizePanel",
   componentType: "ContentSizeFitter",
   properties: {
@@ -1458,14 +1458,14 @@ mcp__unity-mcp-server__component_add({
 
 | 目的 | 推奨ツール |
 |------|-----------|
-| Canvas作成 | `gameobject_create` + `component_add` |
-| UI要素追加 | `gameobject_create` + `component_add` |
-| アンカー設定 | `component_field_set` (RectTransform) |
-| Canvas Scaler設定 | `component_field_set` (CanvasScaler) |
-| Layout Group追加 | `component_add` |
-| UI要素検索 | `ui_find_elements` |
-| UIクリックテスト | `ui_click_element` |
-| UI状態確認 | `ui_get_element_state` |
+| Canvas作成 | `create_gameobject` + `add_component` |
+| UI要素追加 | `create_gameobject` + `add_component` |
+| アンカー設定 | `set_component_field` (RectTransform) |
+| Canvas Scaler設定 | `set_component_field` (CanvasScaler) |
+| Layout Group追加 | `add_component` |
+| UI要素検索 | `find_ui_elements` |
+| UIクリックテスト | `click_ui_element` |
+| UI状態確認 | `get_ui_element_state` |
 | スクリプト作成 | `script_create_class` |
 
 ## Common Workflows
@@ -1474,13 +1474,13 @@ mcp__unity-mcp-server__component_add({
 
 ```javascript
 // Step 1: Canvas作成
-mcp__unity-mcp-server__gameobject_create({ name: "MobileCanvas" })
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__create_gameobject({ name: "MobileCanvas" })
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/MobileCanvas",
   componentType: "Canvas",
   properties: { renderMode: 0 }
 })
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/MobileCanvas",
   componentType: "CanvasScaler",
   properties: {
@@ -1489,32 +1489,32 @@ mcp__unity-mcp-server__component_add({
     matchWidthOrHeight: 0
   }
 })
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/MobileCanvas",
   componentType: "GraphicRaycaster"
 })
 
 // Step 2: Safe Areaパネル
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "SafeArea",
   parentPath: "/MobileCanvas"
 })
 
 // Step 3: ヘッダー（上部ストレッチ）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Header",
   parentPath: "/MobileCanvas/SafeArea"
 })
 // アンカーを上部ストレッチに設定...
 
 // Step 4: コンテンツ（中央ストレッチ）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Content",
   parentPath: "/MobileCanvas/SafeArea"
 })
 
 // Step 5: フッター（下部ストレッチ）
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Footer",
   parentPath: "/MobileCanvas/SafeArea"
 })
@@ -1524,33 +1524,33 @@ mcp__unity-mcp-server__gameobject_create({
 
 ```javascript
 // ScrollView作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "ScrollView",
   parentPath: "/Canvas"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/ScrollView",
   componentType: "ScrollRect"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/ScrollView",
   componentType: "Image"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/ScrollView",
   componentType: "Mask"
 })
 
 // Content作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Content",
   parentPath: "/Canvas/ScrollView"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/ScrollView/Content",
   componentType: "VerticalLayoutGroup",
   properties: {
@@ -1559,7 +1559,7 @@ mcp__unity-mcp-server__component_add({
   }
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/ScrollView/Content",
   componentType: "ContentSizeFitter",
   properties: {
@@ -1635,9 +1635,9 @@ referenceResolution: { x: 1920, y: 1080 }
 
 ## Tool Reference
 
-### ui_find_elements
+### find_ui_elements
 ```javascript
-mcp__unity-mcp-server__ui_find_elements({
+mcp__unity-mcp-server__find_ui_elements({
   elementType: "Button",      // UI component type
   tagFilter: "MainMenu",      // GameObject tag
   namePattern: "Btn_*",       // Name pattern
@@ -1646,9 +1646,9 @@ mcp__unity-mcp-server__ui_find_elements({
 })
 ```
 
-### ui_click_element
+### click_ui_element
 ```javascript
-mcp__unity-mcp-server__ui_click_element({
+mcp__unity-mcp-server__click_ui_element({
   elementPath: "/Canvas/Button",
   clickType: "left",     // left, right, middle
   holdDuration: 0,       // ms
@@ -1656,27 +1656,27 @@ mcp__unity-mcp-server__ui_click_element({
 })
 ```
 
-### ui_get_element_state
+### get_ui_element_state
 ```javascript
-mcp__unity-mcp-server__ui_get_element_state({
+mcp__unity-mcp-server__get_ui_element_state({
   elementPath: "/Canvas/Button",
   includeChildren: false,
   includeInteractableInfo: true
 })
 ```
 
-### ui_set_element_value
+### set_ui_element_value
 ```javascript
-mcp__unity-mcp-server__ui_set_element_value({
+mcp__unity-mcp-server__set_ui_element_value({
   elementPath: "/Canvas/InputField",
   value: "Hello World",
   triggerEvents: true
 })
 ```
 
-### component_field_set (RectTransform)
+### set_component_field (RectTransform)
 ```javascript
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas/Panel",
   componentType: "RectTransform",
   fieldPath: "anchorMin",  // anchorMin, anchorMax, pivot, anchoredPosition, sizeDelta, offsetMin, offsetMax
@@ -1684,9 +1684,9 @@ mcp__unity-mcp-server__component_field_set({
 })
 ```
 
-### component_field_set (CanvasScaler)
+### set_component_field (CanvasScaler)
 ```javascript
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler",
   fieldPath: "matchWidthOrHeight",  // uiScaleMode, referenceResolution, screenMatchMode, matchWidthOrHeight

--- a/.claude-plugin/skills/unity-game-ui-toolkit-design/SKILL.md
+++ b/.claude-plugin/skills/unity-game-ui-toolkit-design/SKILL.md
@@ -2,19 +2,19 @@
 name: unity-game-ui-toolkit-design
 description: UnityのUI Toolkit（USS/UXML/Flexbox）を使用したゲームUIデザイン。HUD、ヘルスバー、インベントリ、スキルバー等のゲームUI要素、PanelSettingsによるスケーリング、Safe Area対応を含む。使用タイミング: ゲームUI設計、HUD作成、USS/UXMLスタイリング、Flexboxレイアウト、PanelSettings設定
 allowed-tools:
-  - mcp__unity-mcp-server__ui_find_elements
-  - mcp__unity-mcp-server__ui_click_element
-  - mcp__unity-mcp-server__ui_get_element_state
-  - mcp__unity-mcp-server__ui_set_element_value
-  - mcp__unity-mcp-server__ui_simulate_input
-  - mcp__unity-mcp-server__component_add
-  - mcp__unity-mcp-server__component_modify
-  - mcp__unity-mcp-server__component_field_set
-  - mcp__unity-mcp-server__component_list
-  - mcp__unity-mcp-server__gameobject_create
-  - mcp__unity-mcp-server__gameobject_modify
-  - mcp__unity-mcp-server__gameobject_find
-  - mcp__unity-mcp-server__asset_database_manage
+  - mcp__unity-mcp-server__find_ui_elements
+  - mcp__unity-mcp-server__click_ui_element
+  - mcp__unity-mcp-server__get_ui_element_state
+  - mcp__unity-mcp-server__set_ui_element_value
+  - mcp__unity-mcp-server__simulate_ui_input
+  - mcp__unity-mcp-server__add_component
+  - mcp__unity-mcp-server__modify_component
+  - mcp__unity-mcp-server__set_component_field
+  - mcp__unity-mcp-server__list_components
+  - mcp__unity-mcp-server__create_gameobject
+  - mcp__unity-mcp-server__modify_gameobject
+  - mcp__unity-mcp-server__find_gameobject
+  - mcp__unity-mcp-server__manage_asset_database
   - mcp__unity-mcp-server__script_edit_structured
   - mcp__unity-mcp-server__script_create_class
   - mcp__unity-mcp-server__script_read
@@ -221,18 +221,18 @@ UI Toolkitは、Webの技術（HTML/CSS）に近いアプローチでUIを構築
 
 ```javascript
 // 1. UIDocumentを持つGameObject作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "UIManager"
 })
 
 // 2. UIDocumentコンポーネントを追加
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/UIManager",
   componentType: "UIDocument"
 })
 
 // 3. PanelSettingsを設定
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/UIManager",
   componentType: "UIDocument",
   fieldPath: "panelSettings",
@@ -1223,13 +1223,13 @@ void ReturnToPool(VisualElement element)
 
 | 目的 | 推奨ツール |
 |------|-----------|
-| UIDocument GameObject作成 | `gameobject_create` + `component_add` |
-| PanelSettings設定 | `component_field_set` |
+| UIDocument GameObject作成 | `create_gameobject` + `add_component` |
+| PanelSettings設定 | `set_component_field` |
 | C#コントローラー作成 | `script_create_class` |
-| UXML/USSファイル作成 | `asset_database_manage` |
-| UI要素検索 | `ui_find_elements` |
-| UIテスト | `ui_click_element`, `ui_simulate_input` |
-| UI状態確認 | `ui_get_element_state` |
+| UXML/USSファイル作成 | `manage_asset_database` |
+| UI要素検索 | `find_ui_elements` |
+| UIテスト | `click_ui_element`, `simulate_ui_input` |
+| UI状態確認 | `get_ui_element_state` |
 
 ## Common Workflows
 
@@ -1237,11 +1237,11 @@ void ReturnToPool(VisualElement element)
 
 ```javascript
 // Step 1: UIDocument用GameObjectを作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "ResponsiveUI"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/ResponsiveUI",
   componentType: "UIDocument"
 })

--- a/.claude-plugin/skills/unity-scene-management/SKILL.md
+++ b/.claude-plugin/skills/unity-scene-management/SKILL.md
@@ -14,13 +14,13 @@ Unityシーン、ゲームオブジェクト、コンポーネントの作成・
 
 ```javascript
 // 読み込み済みシーン一覧
-mcp__unity-mcp-server__scene_list({ includeLoadedOnly: true })
+mcp__unity-mcp-server__list_scenes({ includeLoadedOnly: true })
 
 // 現在のシーン情報
-mcp__unity-mcp-server__scene_info_get({ includeGameObjects: true })
+mcp__unity-mcp-server__get_scene_info({ includeGameObjects: true })
 
 // ヒエラルキー取得（軽量版）
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   nameOnly: true,
   maxObjects: 100
 })
@@ -30,12 +30,12 @@ mcp__unity-mcp-server__gameobject_get_hierarchy({
 
 ```javascript
 // 空のGameObject
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "GameManager"
 })
 
 // プリミティブ
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Floor",
   primitiveType: "plane",
   position: { x: 0, y: 0, z: 0 },
@@ -47,7 +47,7 @@ mcp__unity-mcp-server__gameobject_create({
 
 ```javascript
 // Rigidbodyを追加
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Player",
   componentType: "Rigidbody",
   properties: { mass: 1.5, useGravity: true }
@@ -60,7 +60,7 @@ mcp__unity-mcp-server__component_add({
 
 ```javascript
 // 新規シーンを作成して読み込み
-mcp__unity-mcp-server__scene_create({
+mcp__unity-mcp-server__create_scene({
   sceneName: "Level01",
   path: "Assets/Scenes/",
   loadScene: true,
@@ -72,13 +72,13 @@ mcp__unity-mcp-server__scene_create({
 
 ```javascript
 // 単一シーン読み込み（現在のシーンを置き換え）
-mcp__unity-mcp-server__scene_load({
+mcp__unity-mcp-server__load_scene({
   scenePath: "Assets/Scenes/MainMenu.unity",
   loadMode: "Single"
 })
 
 // 追加読み込み（現在のシーンに追加）
-mcp__unity-mcp-server__scene_load({
+mcp__unity-mcp-server__load_scene({
   scenePath: "Assets/Scenes/UI.unity",
   loadMode: "Additive"
 })
@@ -88,10 +88,10 @@ mcp__unity-mcp-server__scene_load({
 
 ```javascript
 // 現在のシーンを保存
-mcp__unity-mcp-server__scene_save()
+mcp__unity-mcp-server__save_scene()
 
 // 別名で保存
-mcp__unity-mcp-server__scene_save({
+mcp__unity-mcp-server__save_scene({
   scenePath: "Assets/Scenes/Level01_backup.unity",
   saveAs: true
 })
@@ -101,13 +101,13 @@ mcp__unity-mcp-server__scene_save({
 
 ```javascript
 // プロジェクト内の全シーン
-mcp__unity-mcp-server__scene_list()
+mcp__unity-mcp-server__list_scenes()
 
 // ビルド設定に含まれるシーンのみ
-mcp__unity-mcp-server__scene_list({ includeBuildScenesOnly: true })
+mcp__unity-mcp-server__list_scenes({ includeBuildScenesOnly: true })
 
 // 特定シーンの詳細情報
-mcp__unity-mcp-server__scene_info_get({
+mcp__unity-mcp-server__get_scene_info({
   scenePath: "Assets/Scenes/Main.unity",
   includeGameObjects: true
 })
@@ -119,7 +119,7 @@ mcp__unity-mcp-server__scene_info_get({
 
 ```javascript
 // フル指定での作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Enemy",
   primitiveType: "cube",
   parentPath: "/Enemies",
@@ -146,23 +146,23 @@ mcp__unity-mcp-server__gameobject_create({
 
 ```javascript
 // 名前で検索
-mcp__unity-mcp-server__gameobject_find({
+mcp__unity-mcp-server__find_gameobject({
   name: "Player",
   exactMatch: true
 })
 
 // タグで検索
-mcp__unity-mcp-server__gameobject_find({
+mcp__unity-mcp-server__find_gameobject({
   tag: "Enemy"
 })
 
 // レイヤーで検索
-mcp__unity-mcp-server__gameobject_find({
+mcp__unity-mcp-server__find_gameobject({
   layer: 8  // 0-31
 })
 
 // 部分一致検索
-mcp__unity-mcp-server__gameobject_find({
+mcp__unity-mcp-server__find_gameobject({
   name: "Spawn",
   exactMatch: false
 })
@@ -172,14 +172,14 @@ mcp__unity-mcp-server__gameobject_find({
 
 ```javascript
 // Transform変更
-mcp__unity-mcp-server__gameobject_modify({
+mcp__unity-mcp-server__modify_gameobject({
   path: "/Player",
   position: { x: 0, y: 1, z: 0 },
   rotation: { x: 0, y: 90, z: 0 }
 })
 
 // 名前・タグ・レイヤー変更
-mcp__unity-mcp-server__gameobject_modify({
+mcp__unity-mcp-server__modify_gameobject({
   path: "/OldName",
   name: "NewName",
   tag: "Player",
@@ -187,19 +187,19 @@ mcp__unity-mcp-server__gameobject_modify({
 })
 
 // 親オブジェクト変更
-mcp__unity-mcp-server__gameobject_modify({
+mcp__unity-mcp-server__modify_gameobject({
   path: "/Player",
   parentPath: "/Characters"
 })
 
 // 親から外す
-mcp__unity-mcp-server__gameobject_modify({
+mcp__unity-mcp-server__modify_gameobject({
   path: "/Characters/Player",
   parentPath: null
 })
 
 // アクティブ状態変更
-mcp__unity-mcp-server__gameobject_modify({
+mcp__unity-mcp-server__modify_gameobject({
   path: "/Player",
   active: false
 })
@@ -209,17 +209,17 @@ mcp__unity-mcp-server__gameobject_modify({
 
 ```javascript
 // 単一削除
-mcp__unity-mcp-server__gameobject_delete({
+mcp__unity-mcp-server__delete_gameobject({
   path: "/OldObject"
 })
 
 // 複数削除
-mcp__unity-mcp-server__gameobject_delete({
+mcp__unity-mcp-server__delete_gameobject({
   paths: ["/Object1", "/Object2", "/Object3"]
 })
 
 // 子オブジェクトを残す
-mcp__unity-mcp-server__gameobject_delete({
+mcp__unity-mcp-server__delete_gameobject({
   path: "/Parent",
   includeChildren: false
 })
@@ -229,26 +229,26 @@ mcp__unity-mcp-server__gameobject_delete({
 
 ```javascript
 // 軽量版（名前とパスのみ）- 大規模シーン向け
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   nameOnly: true,
   maxObjects: 500
 })
 
 // 詳細版（コンポーネント・Transform含む）- 小規模向け
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   includeComponents: true,
   includeTransform: true,
   maxObjects: 50
 })
 
 // 特定オブジェクト配下のみ
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   rootPath: "/Enemies",
   maxDepth: 2
 })
 
 // 非アクティブオブジェクトを除外
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   includeInactive: false
 })
 ```
@@ -259,13 +259,13 @@ mcp__unity-mcp-server__gameobject_get_hierarchy({
 
 ```javascript
 // 基本追加
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Player",
   componentType: "Rigidbody"
 })
 
 // プロパティ付き
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Player",
   componentType: "BoxCollider",
   properties: {
@@ -276,7 +276,7 @@ mcp__unity-mcp-server__component_add({
 })
 
 // カスタムスクリプト
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Player",
   componentType: "PlayerController"
 })
@@ -284,10 +284,10 @@ mcp__unity-mcp-server__component_add({
 
 ### コンポーネント修正
 
-#### `component_modify` - 複数プロパティを一括変更
+#### `modify_component` - 複数プロパティを一括変更
 
 ```javascript
-mcp__unity-mcp-server__component_modify({
+mcp__unity-mcp-server__modify_component({
   gameObjectPath: "/Player",
   componentType: "Rigidbody",
   properties: {
@@ -298,11 +298,11 @@ mcp__unity-mcp-server__component_modify({
 })
 ```
 
-#### `component_field_set` - 単一フィールドを精密に変更
+#### `set_component_field` - 単一フィールドを精密に変更
 
 ```javascript
 // シリアライズドフィールド（プライベートも可）
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Player",
   componentType: "PlayerController",
   fieldPath: "_moveSpeed",
@@ -310,7 +310,7 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // ネストしたフィールド
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Player",
   componentType: "PlayerController",
   fieldPath: "settings.jumpHeight",
@@ -318,7 +318,7 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // 配列要素
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Player",
   componentType: "Inventory",
   fieldPath: "items[0].count",
@@ -326,7 +326,7 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // オブジェクト参照
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Player",
   componentType: "PlayerController",
   fieldPath: "targetTransform",
@@ -334,7 +334,7 @@ mcp__unity-mcp-server__component_field_set({
 })
 
 // Enum値
-mcp__unity-mcp-server__component_field_set({
+mcp__unity-mcp-server__set_component_field({
   gameObjectPath: "/Player",
   componentType: "PlayerController",
   fieldPath: "state",
@@ -342,9 +342,9 @@ mcp__unity-mcp-server__component_field_set({
 })
 ```
 
-### `component_modify` vs `component_field_set`
+### `modify_component` vs `set_component_field`
 
-| 項目 | component_modify | component_field_set |
+| 項目 | modify_component | set_component_field |
 |------|------------------|---------------------|
 | 用途 | 複数プロパティ一括 | 単一フィールド精密 |
 | ネスト対応 | ❌ トップレベルのみ | ✅ ドット記法対応 |
@@ -356,18 +356,18 @@ mcp__unity-mcp-server__component_field_set({
 
 ```javascript
 // コンポーネント一覧
-mcp__unity-mcp-server__component_list({
+mcp__unity-mcp-server__list_components({
   gameObjectPath: "/Player"
 })
 
 // コンポーネント削除
-mcp__unity-mcp-server__component_remove({
+mcp__unity-mcp-server__remove_component({
   gameObjectPath: "/Player",
   componentType: "OldScript"
 })
 
 // 同じ型が複数ある場合
-mcp__unity-mcp-server__component_remove({
+mcp__unity-mcp-server__remove_component({
   gameObjectPath: "/Player",
   componentType: "AudioSource",
   componentIndex: 1  // 2番目のAudioSource
@@ -378,17 +378,17 @@ mcp__unity-mcp-server__component_remove({
 
 ```javascript
 // カテゴリで検索
-mcp__unity-mcp-server__component_get_types({
+mcp__unity-mcp-server__get_component_types({
   category: "Physics"  // Physics, Rendering, UI, etc.
 })
 
 // 名前で検索
-mcp__unity-mcp-server__component_get_types({
+mcp__unity-mcp-server__get_component_types({
   search: "Collider"
 })
 
 // AddComponentで追加可能なもののみ
-mcp__unity-mcp-server__component_get_types({
+mcp__unity-mcp-server__get_component_types({
   onlyAddable: true
 })
 ```
@@ -399,13 +399,13 @@ mcp__unity-mcp-server__component_get_types({
 
 ```javascript
 // オブジェクト統計
-mcp__unity-mcp-server__analysis_scene_contents_analyze({
+mcp__unity-mcp-server__analyze_scene_contents({
   groupByType: true,
   includePrefabInfo: true
 })
 
 // メモリ情報付き
-mcp__unity-mcp-server__analysis_scene_contents_analyze({
+mcp__unity-mcp-server__analyze_scene_contents({
   includeMemoryInfo: true
 })
 ```
@@ -414,13 +414,13 @@ mcp__unity-mcp-server__analysis_scene_contents_analyze({
 
 ```javascript
 // 特定コンポーネントを持つオブジェクトを検索
-mcp__unity-mcp-server__analysis_component_find({
+mcp__unity-mcp-server__find_by_component({
   componentType: "Light",
   searchScope: "scene"
 })
 
 // プレハブも含めて検索
-mcp__unity-mcp-server__analysis_component_find({
+mcp__unity-mcp-server__find_by_component({
   componentType: "AudioSource",
   searchScope: "all",
   includeInactive: true
@@ -431,7 +431,7 @@ mcp__unity-mcp-server__analysis_component_find({
 
 ```javascript
 // GameObject詳細
-mcp__unity-mcp-server__analysis_gameobject_details_get({
+mcp__unity-mcp-server__get_gameobject_details({
   gameObjectName: "Player",
   includeComponents: true,
   includeMaterials: true,
@@ -440,14 +440,14 @@ mcp__unity-mcp-server__analysis_gameobject_details_get({
 })
 
 // コンポーネントの全プロパティ値
-mcp__unity-mcp-server__analysis_component_values_get({
+mcp__unity-mcp-server__get_component_values({
   gameObjectName: "Player",
   componentType: "Rigidbody",
   includePrivateFields: true
 })
 
 // オブジェクト参照関係
-mcp__unity-mcp-server__analysis_object_references_get({
+mcp__unity-mcp-server__get_object_references({
   gameObjectName: "Player",
   includeAssetReferences: true,
   includeHierarchyReferences: true
@@ -460,17 +460,17 @@ mcp__unity-mcp-server__analysis_object_references_get({
 
 ```javascript
 // 1. 新規シーン作成
-mcp__unity-mcp-server__scene_create({
+mcp__unity-mcp-server__create_scene({
   sceneName: "GameLevel",
   loadScene: true
 })
 
 // 2. 環境オブジェクト作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Environment"
 })
 
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Ground",
   primitiveType: "plane",
   parentPath: "/Environment",
@@ -478,11 +478,11 @@ mcp__unity-mcp-server__gameobject_create({
 })
 
 // 3. ライティング設定
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "Sun"
 })
 
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Sun",
   componentType: "Light",
   properties: {
@@ -493,34 +493,34 @@ mcp__unity-mcp-server__component_add({
 })
 
 // 4. 保存
-mcp__unity-mcp-server__scene_save()
+mcp__unity-mcp-server__save_scene()
 ```
 
 ### UIキャンバス構築
 
 ```javascript
 // Canvas作成
-mcp__unity-mcp-server__gameobject_create({ name: "Canvas" })
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__create_gameobject({ name: "Canvas" })
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas",
   componentType: "Canvas",
   properties: { renderMode: "ScreenSpaceOverlay" }
 })
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas",
   componentType: "CanvasScaler"
 })
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas",
   componentType: "GraphicRaycaster"
 })
 
 // ボタン追加
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "StartButton",
   parentPath: "/Canvas"
 })
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/Canvas/StartButton",
   componentType: "Button"
 })
@@ -530,14 +530,14 @@ mcp__unity-mcp-server__component_add({
 
 ```javascript
 // 物理オブジェクト作成
-mcp__unity-mcp-server__gameobject_create({
+mcp__unity-mcp-server__create_gameobject({
   name: "PhysicsCube",
   primitiveType: "cube",
   position: { x: 0, y: 5, z: 0 }
 })
 
 // Rigidbody追加
-mcp__unity-mcp-server__component_add({
+mcp__unity-mcp-server__add_component({
   gameObjectPath: "/PhysicsCube",
   componentType: "Rigidbody",
   properties: { mass: 1.0 }
@@ -568,7 +568,7 @@ gameObjectPath: "/Parent/Child/GrandChild"
 tag: "CustomEnemy"  // エラー
 
 // ✅ 事前にタグを追加
-mcp__unity-mcp-server__editor_tags_manage({
+mcp__unity-mcp-server__manage_tags({
   action: "add",
   tagName: "CustomEnemy"
 })
@@ -578,10 +578,10 @@ mcp__unity-mcp-server__editor_tags_manage({
 
 ```javascript
 // ❌ 非アクティブが見つからない
-mcp__unity-mcp-server__gameobject_find({ name: "HiddenObject" })
+mcp__unity-mcp-server__find_gameobject({ name: "HiddenObject" })
 
 // ✅ includeInactiveを明示
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   includeInactive: true
 })
 ```
@@ -590,20 +590,20 @@ mcp__unity-mcp-server__gameobject_get_hierarchy({
 
 ```javascript
 // ❌ 全情報を取得（トークン消費大）
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   includeComponents: true,
   includeTransform: true,
   maxObjects: -1  // 無制限
 })
 
 // ✅ 軽量版で概要把握
-mcp__unity-mcp-server__gameobject_get_hierarchy({
+mcp__unity-mcp-server__get_hierarchy({
   nameOnly: true,
   maxObjects: 100
 })
 
 // ✅ 必要な部分のみ詳細取得
-mcp__unity-mcp-server__analysis_gameobject_details_get({
+mcp__unity-mcp-server__get_gameobject_details({
   gameObjectName: "SpecificObject",
   includeComponents: true
 })
@@ -613,32 +613,32 @@ mcp__unity-mcp-server__analysis_gameobject_details_get({
 
 ```javascript
 // ✅ 重要な変更後は保存
-mcp__unity-mcp-server__scene_save()
+mcp__unity-mcp-server__save_scene()
 ```
 
 ## Tool Reference
 
 | ツール | 用途 |
 |--------|------|
-| `scene_create` | シーン作成 |
-| `scene_load` | シーン読み込み |
-| `scene_save` | シーン保存 |
-| `scene_list` | シーン一覧 |
-| `scene_info_get` | シーン情報取得 |
-| `gameobject_create` | GameObject作成 |
-| `gameobject_find` | GameObject検索 |
-| `gameobject_modify` | GameObject修正 |
-| `gameobject_delete` | GameObject削除 |
-| `gameobject_get_hierarchy` | ヒエラルキー取得 |
-| `component_add` | コンポーネント追加 |
-| `component_modify` | コンポーネント修正（一括） |
-| `component_field_set` | フィールド修正（精密） |
-| `component_remove` | コンポーネント削除 |
-| `component_list` | コンポーネント一覧 |
-| `component_get_types` | 利用可能な型一覧 |
-| `analysis_scene_contents_analyze` | シーン分析 |
-| `analysis_component_find` | コンポーネント検索 |
-| `analysis_gameobject_details_get` | 詳細情報取得 |
-| `analysis_component_values_get` | プロパティ値取得 |
-| `editor_tags_manage` | タグ管理 |
-| `editor_layers_manage` | レイヤー管理 |
+| `create_scene` | シーン作成 |
+| `load_scene` | シーン読み込み |
+| `save_scene` | シーン保存 |
+| `list_scenes` | シーン一覧 |
+| `get_scene_info` | シーン情報取得 |
+| `create_gameobject` | GameObject作成 |
+| `find_gameobject` | GameObject検索 |
+| `modify_gameobject` | GameObject修正 |
+| `delete_gameobject` | GameObject削除 |
+| `get_hierarchy` | ヒエラルキー取得 |
+| `add_component` | コンポーネント追加 |
+| `modify_component` | コンポーネント修正（一括） |
+| `set_component_field` | フィールド修正（精密） |
+| `remove_component` | コンポーネント削除 |
+| `list_components` | コンポーネント一覧 |
+| `get_component_types` | 利用可能な型一覧 |
+| `analyze_scene_contents` | シーン分析 |
+| `find_by_component` | コンポーネント検索 |
+| `get_gameobject_details` | 詳細情報取得 |
+| `get_component_values` | プロパティ値取得 |
+| `manage_tags` | タグ管理 |
+| `manage_layers` | レイヤー管理 |

--- a/tests/RESULTS_FORMAT.md
+++ b/tests/RESULTS_FORMAT.md
@@ -29,7 +29,6 @@
   - `total`: チェックリスト行（`- [ ]` または `- [x]`）の合計
 - latest 更新: 再計算後のレポート全文を `tests/.reports/latest.md` にも上書きする。
 
-
 テンプレート（ランファイルの雛形・例）
 ```
 # <Run Title> テストレポート
@@ -54,10 +53,10 @@
 - [x] S00-00 ラン初期化 — pass (0 ms) restored:true
 
 ## Scene
-- [ ] U10-01 scene_create … restored:true
+- [ ] U10-01 create_scene … restored:true
 
 ## GameObject
-- [ ] U20-01 gameobject_create … restored:true
+- [ ] U20-01 create_gameobject … restored:true
 
 ## 詳細（必要なケースのみ）
 <details>

--- a/tests/test-mcp-assets-tools.md
+++ b/tests/test-mcp-assets-tools.md
@@ -6,17 +6,17 @@
 - 取得/検索系は非破壊に。検証で作成した一時アセットはテスト終了時に削除。
 
 チェックリスト（Markdown）
-- [ ] U90-01: package_manage（list, includeBuiltIn=false）
-- [ ] U90-02: asset_database_manage（find_assets, t:Texture2D）
-- [ ] U90-03: asset_import_settings_manage（action=get）
+- [ ] U90-01: package_manager（list, includeBuiltIn=false）
+- [ ] U90-02: manage_asset_database（find_assets, t:Texture2D）
+- [ ] U90-03: manage_asset_import_settings（action=get）
 - [ ] U90-E01: 無効 filter で fail
 - [ ] U90-E02: 存在しない assetPath で fail
 
 ## 正常系
 
-- U90-01: `package_manage`（`action=list`, `includeBuiltIn=false`）→ 一覧取得
-- U90-02: `asset_database_manage`（`action=find_assets`, `filter=t:Texture2D`）→ 検索
-- U90-03: `asset_import_settings_manage`（`action=get`）→ 1件の設定取得
+- U90-01: `package_manager`（`action=list`, `includeBuiltIn=false`）→ 一覧取得
+- U90-02: `manage_asset_database`（`action=find_assets`, `filter=t:Texture2D`）→ 検索
+- U90-03: `manage_asset_import_settings`（`action=get`）→ 1件の設定取得
 
 ## 異常系
 

--- a/tests/test-mcp-capture-tools.md
+++ b/tests/test-mcp-capture-tools.md
@@ -6,16 +6,16 @@
 - 生成したスクリーンショット/動画はテスト成果物として記録し、必要に応じてクリーンアップポリシーに従って削除可能。
 
 チェックリスト（Markdown）
-- [ ] U70-01: screenshot_capture（game, includeUI=true）
-- [ ] U70-02: screenshot_analyze（analysisType=basic）
+- [ ] U70-01: capture_screenshot（game, includeUI=true）
+- [ ] U70-02: analyze_screenshot（analysisType=basic）
 - [ ] U70-03: capture_video_for（durationSec=2）
 - [ ] U70-E01: 不正 captureMode で fail
 - [ ] U70-E02: Recorder 欠如で fail
 
 ## 正常系
 
-- U70-01: `screenshot_capture`（`captureMode=game`, `includeUI=true`）→ 画像作成
-- U70-02: `screenshot_analyze`（`analysisType=basic`）→ 解析
+- U70-01: `capture_screenshot`（`captureMode=game`, `includeUI=true`）→ 画像作成
+- U70-02: `analyze_screenshot`（`analysisType=basic`）→ 解析
 - U70-03: `capture_video_for`（`durationSec=2`）→ 動画作成
 
 ## 異常系

--- a/tests/test-mcp-cleanup-tools.md
+++ b/tests/test-mcp-cleanup-tools.md
@@ -11,14 +11,14 @@
 
 ## 正常系
 
-- U170-01: `gameobject_delete`（`/LLMTEST_Cube`, `/LLMTEST_Cube_Instance`）→ 削除
-- U170-02: `asset_database_manage`（`action=delete` で `Assets/LLMTEST_*` を順次）→ 削除
+- U170-01: `delete_gameobject`（`/LLMTEST_Cube`, `/LLMTEST_Cube_Instance`）→ 削除
+- U170-02: `manage_asset_database`（`action=delete` で `Assets/LLMTEST_*` を順次）→ 削除
 
 ## 異常系
 
 - U170-E01: 不在対象の再削除 → `skip` または `fail`
 
 チェックリスト（Markdown）
-- [ ] U170-01: gameobject_delete（/LLMTEST_Cube, /LLMTEST_Cube_Instance）
-- [ ] U170-02: asset_database_manage（delete, Assets/LLMTEST_*）
+- [ ] U170-01: delete_gameobject（/LLMTEST_Cube, /LLMTEST_Cube_Instance）
+- [ ] U170-02: manage_asset_database（delete, Assets/LLMTEST_*）
 - [ ] U170-E01: 不在対象の再削除は skip/fail として扱う

--- a/tests/test-mcp-common-tools.md
+++ b/tests/test-mcp-common-tools.md
@@ -7,19 +7,19 @@
 - Node 側は全コマンドに `workspaceRoot` を付与
 
 チェックリスト（Markdown）
-- [ ] U00-01: playmode_get_state（isPlaying=false）
-- [ ] U00-02: settings_get（player/quality/graphics）
-- [ ] U00-03: system_get_command_stats（集計）
+- [ ] U00-01: get_editor_state（isPlaying=false）
+- [ ] U00-02: get_project_settings（player/quality/graphics）
+- [ ] U00-03: get_command_stats（集計）
 - [ ] U00-E01: playmode_wait_for_state（isPlaying=true, timeoutMs=1）で TIMEOUT（fail）
-- [ ] U00-E02: settings_get（未知フラグ）でバリデーション fail
+- [ ] U00-E02: get_project_settings（未知フラグ）でバリデーション fail
 
 ## 正常系
 
-- U00-01: `playmode_get_state` → `isPlaying=false`
-- U00-02: `settings_get`（player/quality/graphics）→ 取得成功
-- U00-03: `system_get_command_stats` → 集計取得
+- U00-01: `get_editor_state` → `isPlaying=false`
+- U00-02: `get_project_settings`（player/quality/graphics）→ 取得成功
+- U00-03: `get_command_stats` → 集計取得
 
 ## 異常系
 
 - U00-E01: `playmode_wait_for_state`（`isPlaying=true`, `timeoutMs=1`）→ タイムアウト
-- U00-E02: `settings_get` に未知フラグ → バリデーションエラー
+- U00-E02: `get_project_settings` に未知フラグ → バリデーションエラー

--- a/tests/test-mcp-compilation-refresh-tools.md
+++ b/tests/test-mcp-compilation-refresh-tools.md
@@ -6,14 +6,14 @@
 - リフレッシュ/コンパイルは非破壊だが、他カテゴリと干渉しないタイミングで実施し副作用が残らないようにする。
 
 チェックリスト（Markdown）
-- [ ] U160-01: system_refresh_assets（完了）
-- [ ] U160-02: compilation_get_state（includeMessages=true, エラー0）
+- [ ] U160-01: refresh_assets（完了）
+- [ ] U160-02: get_compilation_state（includeMessages=true, エラー0）
 - [ ] U160-E01: 無効 maxMessages（負数）で fail
 
 ## 正常系
 
-- U160-01: `system_refresh_assets` → 完了
-- U160-02: `compilation_get_state`（`includeMessages=true`）→ `isCompiling=false`・エラー0（なければ `fail`）
+- U160-01: `refresh_assets` → 完了
+- U160-02: `get_compilation_state`（`includeMessages=true`）→ `isCompiling=false`・エラー0（なければ `fail`）
 
 ## 異常系
 

--- a/tests/test-mcp-component-tools.md
+++ b/tests/test-mcp-component-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `component_list`/`analysis_component_values_get` の前後比較（追加/削除/値変更）。
-- 構造検証: `analysis_component_find` の一致件数で確認。
-- 参照検証: 依存エラーなどはコンソールログ確認や `analysis_object_references_get` 併用。
+- 差分検証: `list_components`/`get_component_values` の前後比較（追加/削除/値変更）。
+- 構造検証: `find_by_component` の一致件数で確認。
+- 参照検証: 依存エラーなどはコンソールログ確認や `get_object_references` 併用。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
@@ -20,22 +20,22 @@
 前提: 対象 `/LLMTEST_Cube`（未存在なら先に作成）
 
 チェックリスト（Markdown）
-- [ ] U30-01: component_add（Rigidbody）
-- [ ] U30-02: analysis_component_values_get（Rigidbody）
-- [ ] U30-03: component_modify（useGravity=false 等）
-- [ ] U30-04: component_field_set（SerializeField 更新）
-- [ ] U30-05: component_list（Rigidbody を含む）
+- [ ] U30-01: add_component（Rigidbody）
+- [ ] U30-02: get_component_values（Rigidbody）
+- [ ] U30-03: modify_component（useGravity=false 等）
+- [ ] U30-04: set_component_field（SerializeField 更新）
+- [ ] U30-05: list_components（Rigidbody を含む）
 - [ ] U30-E01: 未知 componentType で fail
 - [ ] U30-E02: 不正プロパティ/型不一致で fail
 - [ ] U30-E03: 対象なしで fail
 
 ## 正常系
 
-- U30-01: `component_add`（`Rigidbody`）→ 成功
-- U30-02: `analysis_component_values_get`（`Rigidbody`）→ 値取得
-- U30-03: `component_modify`（`useGravity=false` 等）→ 反映
-- U30-04: `component_field_set`（SerializeField 値更新）→ 反映
-- U30-05: `component_list` → 追加済みが列挙
+- U30-01: `add_component`（`Rigidbody`）→ 成功
+- U30-02: `get_component_values`（`Rigidbody`）→ 値取得
+- U30-03: `modify_component`（`useGravity=false` 等）→ 反映
+- U30-04: `set_component_field`（SerializeField 値更新）→ 反映
+- U30-05: `list_components` → 追加済みが列挙
 
 ## 異常系
 

--- a/tests/test-mcp-console-tools.md
+++ b/tests/test-mcp-console-tools.md
@@ -8,7 +8,7 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `console_read` 前後でログ件数/最新時刻/フィルタ結果を比較。
+- 差分検証: `read_console` 前後でログ件数/最新時刻/フィルタ結果を比較。
 - 構造検証: ログ種別（Error/Warning/Info）やフィルタ適用の有無を確認。
 - 参照検証: 期待したエラーメッセージID/キーワードの出現有無を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
@@ -17,14 +17,14 @@
 - クリア実行後は必要に応じてログを再度生成するなど、他テストへの影響が出ないように順序・分離を保つ。
 
 チェックリスト（Markdown）
-- [ ] U80-01: console_read（count=50）
-- [ ] U80-02: console_clear（preserveErrors/Warnings=true）
+- [ ] U80-01: read_console（count=50）
+- [ ] U80-02: clear_console（preserveErrors/Warnings=true）
 - [ ] U80-E01: 不正 logTypes 値で fail
 
 ## 正常系
 
-- U80-01: `console_read`（`count=50`）→ 直近ログ取得
-- U80-02: `console_clear`（`preserveErrors=true`, `preserveWarnings=true`）→ エラー/警告保持
+- U80-01: `read_console`（`count=50`）→ 直近ログ取得
+- U80-02: `clear_console`（`preserveErrors=true`, `preserveWarnings=true`）→ エラー/警告保持
 
 ## 異常系
 

--- a/tests/test-mcp-gameobject-tools.md
+++ b/tests/test-mcp-gameobject-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `analysis_gameobject_details_get` や `gameobject_get_hierarchy` の前後比較（存在/親子/Transform/タグ/レイヤ）。
-- 構造検証: `gameobject_find` の一致件数を確認。
-- 参照検証: 参照/依存関係は `analysis_object_references_get` で件数期待を確認。
+- 差分検証: `get_gameobject_details` や `get_hierarchy` の前後比較（存在/親子/Transform/タグ/レイヤ）。
+- 構造検証: `find_gameobject` の一致件数を確認。
+- 参照検証: 参照/依存関係は `get_object_references` で件数期待を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
@@ -20,20 +20,20 @@
 前提: 対象名 `/LLMTEST_Cube`
 
 チェックリスト（Markdown）
-- [ ] U20-01: gameobject_create（Cube）
-- [ ] U20-02: analysis_gameobject_details_get（Transform/Renderer）
-- [ ] U20-03: gameobject_modify（位置/回転/スケール）
-- [ ] U20-04: gameobject_get_hierarchy（ルートに LLMTEST_Cube）
+- [ ] U20-01: create_gameobject（Cube）
+- [ ] U20-02: get_gameobject_details（Transform/Renderer）
+- [ ] U20-03: modify_gameobject（位置/回転/スケール）
+- [ ] U20-04: get_hierarchy（ルートに LLMTEST_Cube）
 - [ ] U20-E01: 不在 parentPath で fail
 - [ ] U20-E02: 不正 path で fail
 - [ ] U20-E03: 無効スケール等でバリデーション fail
 
 ## 正常系
 
-- U20-01: `gameobject_create`（`primitiveType=Cube`）→ 生成
-- U20-02: `analysis_gameobject_details_get` → Transform/Renderer 取得
-- U20-03: `gameobject_modify`（位置/回転/スケール）→ 反映確認
-- U20-04: `gameobject_get_hierarchy` → ルートに `LLMTEST_Cube`
+- U20-01: `create_gameobject`（`primitiveType=Cube`）→ 生成
+- U20-02: `get_gameobject_details` → Transform/Renderer 取得
+- U20-03: `modify_gameobject`（位置/回転/スケール）→ 反映確認
+- U20-04: `get_hierarchy` → ルートに `LLMTEST_Cube`
 
 ## 異常系
 

--- a/tests/test-mcp-input-simulation-tools.md
+++ b/tests/test-mcp-input-simulation-tools.md
@@ -8,7 +8,7 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `ui_get_element_state`/ゲーム状態のスクリーンショット（任意）で操作前後の状態差を確認。
+- 差分検証: `get_ui_element_state`/ゲーム状態のスクリーンショット（任意）で操作前後の状態差を確認。
 - 構造検証: 対象要素の interactable/selected 変化で確認。
 - 参照検証: 期待されたログ/イベント（Console/Animator 等）が出力されるか補助確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。

--- a/tests/test-mcp-input-tools.md
+++ b/tests/test-mcp-input-tools.md
@@ -8,7 +8,7 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `input_actions_state_get` で前後比較（actions/maps/bindings の増減）。
+- 差分検証: `get_input_actions_state` で前後比較（actions/maps/bindings の増減）。
 - 構造検証: `find_ui_elements` 等と併用し、UI の反応/操作可能の変化を確認（必要時）。
 - 参照検証: control schemes や devices の有効性/割当変化を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
@@ -17,13 +17,13 @@
 - 追加したアクションマップ/アクション/バインディング/スキームは全てテスト終了時に削除し、既存状態に影響を残さない。
 
 チェックリスト（Markdown）
-- [ ] U60-01: input_actions_state_get（存在確認）
-- [ ] U60-02: input_action_map_create（LLMTEST_Map）
-- [ ] U60-03: input_action_add（Jump, Button）
-- [ ] U60-04: input_binding_add（<Keyboard>/space）
-- [ ] U60-05: input_binding_composite_create（2D Vector: WASD）
-- [ ] U60-06: input_control_schemes_manage（Keyboard&Mouse）
-- [ ] U60-07: input_actions_asset_analyze（統計）
+- [ ] U60-01: get_input_actions_state（存在確認）
+- [ ] U60-02: create_action_map（LLMTEST_Map）
+- [ ] U60-03: add_input_action（Jump, Button）
+- [ ] U60-04: add_input_binding（<Keyboard>/space）
+- [ ] U60-05: create_composite_binding（2D Vector: WASD）
+- [ ] U60-06: manage_control_schemes（Keyboard&Mouse）
+- [ ] U60-07: analyze_input_actions_asset（統計）
 - [ ] U60-08: remove 系で片付け
 - [ ] U60-E01: 重複バインディングで fail or notes
 - [ ] U60-E02: 不正デバイス/パスで fail
@@ -31,13 +31,13 @@
 
 ## 正常系（アセットが存在する場合）
 
-- U60-01: `input_actions_state_get` → 状態取得
-- U60-02: `input_action_map_create`（`LLMTEST_Map`）→ 作成
-- U60-03: `input_action_add`（`Jump`, Button）→ 追加
-- U60-04: `input_binding_add`（`<Keyboard>/space`）→ 追加
-- U60-05: `input_binding_composite_create`（2D Vector: WASD）→ 追加
-- U60-06: `input_control_schemes_manage`（`Keyboard&Mouse`）→ 追加/確認
-- U60-07: `input_actions_asset_analyze` → 統計
+- U60-01: `get_input_actions_state` → 状態取得
+- U60-02: `create_action_map`（`LLMTEST_Map`）→ 作成
+- U60-03: `add_input_action`（`Jump`, Button）→ 追加
+- U60-04: `add_input_binding`（`<Keyboard>/space`）→ 追加
+- U60-05: `create_composite_binding`（2D Vector: WASD）→ 追加
+- U60-06: `manage_control_schemes`（`Keyboard&Mouse`）→ 追加/確認
+- U60-07: `analyze_input_actions_asset` → 統計
 - U60-08: 片付け（remove 系）→ 正常削除
 
 ## 異常系

--- a/tests/test-mcp-layers-tags-tools.md
+++ b/tests/test-mcp-layers-tags-tools.md
@@ -6,29 +6,29 @@
 - 追加したレイヤー/タグはテスト終了時に削除（元の設定に戻す）。
 
 チェックリスト（Markdown）
-- [ ] L10-01: editor_layers_manage（action=get）→ 一覧取得
-- [ ] L10-02: editor_layers_manage（action=add, layerName=LLMTEST_Layer）→ 追加
-- [ ] L10-03: editor_layers_manage（action=get_by_name, layerName=LLMTEST_Layer）→ 存在確認
-- [ ] L10-04: editor_layers_manage（action=remove, layerName=LLMTEST_Layer）→ 削除
+- [ ] L10-01: manage_layers（action=get）→ 一覧取得
+- [ ] L10-02: manage_layers（action=add, layerName=LLMTEST_Layer）→ 追加
+- [ ] L10-03: manage_layers（action=get_by_name, layerName=LLMTEST_Layer）→ 存在確認
+- [ ] L10-04: manage_layers（action=remove, layerName=LLMTEST_Layer）→ 削除
 - [ ] L10-E01: 予約名/不正名で add → fail（検証）
 - [ ] L10-E02: 不存在 remove → fail もしくは適切な応答
-- [ ] T10-01: editor_tags_manage（action=get）→ 一覧取得
-- [ ] T10-02: editor_tags_manage（action=add, tagName=LLMTEST_Tag）→ 追加
-- [ ] T10-03: editor_tags_manage（action=remove, tagName=LLMTEST_Tag）→ 削除
+- [ ] T10-01: manage_tags（action=get）→ 一覧取得
+- [ ] T10-02: manage_tags（action=add, tagName=LLMTEST_Tag）→ 追加
+- [ ] T10-03: manage_tags（action=remove, tagName=LLMTEST_Tag）→ 削除
 - [ ] T10-E01: 不正名 add/remove → fail
 
 ## 正常系
 
-- L10-01: `editor_layers_manage`（`action=get`）→ 一覧
-- L10-02: `editor_layers_manage`（`action=add`, `layerName=LLMTEST_Layer`）→ 追加
-- L10-03: `editor_layers_manage`（`action=get_by_name`）→ 存在
-- L10-04: `editor_layers_manage`（`action=remove`）→ 削除
-- T10-01: `editor_tags_manage`（`action=get`）→ 一覧
-- T10-02: `editor_tags_manage`（`action=add`, `tagName=LLMTEST_Tag`）→ 追加
-- T10-03: `editor_tags_manage`（`action=remove`, `tagName=LLMTEST_Tag`）→ 削除
+- L10-01: `manage_layers`（`action=get`）→ 一覧
+- L10-02: `manage_layers`（`action=add`, `layerName=LLMTEST_Layer`）→ 追加
+- L10-03: `manage_layers`（`action=get_by_name`）→ 存在
+- L10-04: `manage_layers`（`action=remove`）→ 削除
+- T10-01: `manage_tags`（`action=get`）→ 一覧
+- T10-02: `manage_tags`（`action=add`, `tagName=LLMTEST_Tag`）→ 追加
+- T10-03: `manage_tags`（`action=remove`, `tagName=LLMTEST_Tag`）→ 削除
 
 ## 異常系
 
-- L10-E01: `editor_layers_manage`（`action=add`, 予約名/不正形式）→ `fail`
-- L10-E02: `editor_layers_manage`（`action=remove`, 存在しない）→ `fail` または適切応答
-- T10-E01: `editor_tags_manage`（`action=add/remove`, 不正名）→ `fail`
+- L10-E01: `manage_layers`（`action=add`, 予約名/不正形式）→ `fail`
+- L10-E02: `manage_layers`（`action=remove`, 存在しない）→ `fail` または適切応答
+- T10-E01: `manage_tags`（`action=add/remove`, 不正名）→ `fail`

--- a/tests/test-mcp-material-tools.md
+++ b/tests/test-mcp-material-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `asset_material_modify` 適用の前後でプロパティ値を比較（事前は `asset_material_create`/既存読取）。
+- 差分検証: `modify_material` 適用の前後でプロパティ値を比較（事前は `create_material`/既存読取）。
 - 構造検証: マテリアルの shader/keywords 変化を確認。
-- 参照検証: マテリアル参照箇所の増減は `analysis_object_references_get` で補助。
+- 参照検証: マテリアル参照箇所の増減は `get_object_references` で補助。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
@@ -20,16 +20,16 @@
 前提: `Assets/LLMTEST_Materials/LLMTEST_Mat.mat`
 
 チェックリスト（Markdown）
-- [ ] U40-01: asset_material_create（Unlit/Color, 赤）
-- [ ] U40-02: asset_material_modify（青へ変更）
+- [ ] U40-01: create_material（Unlit/Color, 赤）
+- [ ] U40-02: modify_material（青へ変更）
 - [ ] U40-E01: Assets 外パスで fail
 - [ ] U40-E02: 不正シェーダで fail
 - [ ] U40-E03: 未存在プロパティ/型不一致で fail
 
 ## 正常系
 
-- U40-01: `asset_material_create`（`shader=Unlit/Color`, 色=赤）→ 成功
-- U40-02: `asset_material_modify`（色=青）→ 成功
+- U40-01: `create_material`（`shader=Unlit/Color`, 色=赤）→ 成功
+- U40-02: `modify_material`（色=青）→ 成功
 
 ## 異常系
 

--- a/tests/test-mcp-play-pause-tools.md
+++ b/tests/test-mcp-play-pause-tools.md
@@ -8,25 +8,25 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `playmode_get_state` の `isPlaying` 等の前後比較。
+- 差分検証: `get_editor_state` の `isPlaying` 等の前後比較。
 - 構造検証: 再生/停止中のログや Animator/Update の動作で補助確認。
-- 参照検証: `console_read` によるステート遷移ログの有無を確認。
+- 参照検証: `read_console` によるステート遷移ログの有無を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
-- テスト終了時は必ず `playmode_stop` で `isPlaying=false` の静止状態に戻す。
+- テスト終了時は必ず `stop_game` で `isPlaying=false` の静止状態に戻す。
 
 チェックリスト（Markdown）
-- [ ] U120-01: playmode_play → playmode_wait_for_state(isPlaying=true)
-- [ ] U120-02: playmode_pause → playmode_get_state
-- [ ] U120-03: playmode_stop → playmode_wait_for_state(isPlaying=false)
+- [ ] U120-01: play_game → playmode_wait_for_state(isPlaying=true)
+- [ ] U120-02: pause_game → get_editor_state
+- [ ] U120-03: stop_game → playmode_wait_for_state(isPlaying=false)
 - [ ] U120-E01: 短すぎる timeoutMs で TIMEOUT（fail）
 
 ## 正常系
 
-- U120-01: `playmode_play` → `playmode_wait_for_state(isPlaying=true)`
-- U120-02: `playmode_pause` → `playmode_get_state`
-- U120-03: `playmode_stop` → `playmode_wait_for_state(isPlaying=false)`
+- U120-01: `play_game` → `playmode_wait_for_state(isPlaying=true)`
+- U120-02: `pause_game` → `get_editor_state`
+- U120-03: `stop_game` → `playmode_wait_for_state(isPlaying=false)`
 
 ## 異常系
 

--- a/tests/test-mcp-prefab-tools.md
+++ b/tests/test-mcp-prefab-tools.md
@@ -8,9 +8,9 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `asset_prefab_open` 後に `component_list`/`analysis_gameobject_details_get` の前後比較。
+- 差分検証: `open_prefab` 後に `list_components`/`get_gameobject_details` の前後比較。
 - 構造検証: Prefab インスタンス化後のヒエラルキー差分で確認。
-- 参照検証: 参照/依存の増減を `analysis_object_references_get` で確認。
+- 参照検証: 参照/依存の増減を `get_object_references` で確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
@@ -20,20 +20,20 @@
 前提: 元 `/LLMTEST_Cube`、Prefab `Assets/LLMTEST_Prefabs/LLMTEST_Cube.prefab`
 
 チェックリスト（Markdown）
-- [ ] U50-01: asset_prefab_create（/LLMTEST_Cube → Prefab 作成）
-- [ ] U50-02: asset_prefab_open → component_add(BoxCollider) → asset_prefab_save → asset_prefab_exit_mode
-- [ ] U50-03: asset_prefab_instantiate（LLMTEST_Cube_Instance）
-- [ ] U50-04: asset_prefab_modify（applyToInstances=true で反映）
+- [ ] U50-01: create_prefab（/LLMTEST_Cube → Prefab 作成）
+- [ ] U50-02: open_prefab → add_component(BoxCollider) → save_prefab → exit_prefab_mode
+- [ ] U50-03: instantiate_prefab（LLMTEST_Cube_Instance）
+- [ ] U50-04: modify_prefab（applyToInstances=true で反映）
 - [ ] U50-E01: Assets 外パス保存で fail
 - [ ] U50-E02: 存在しない Prefab の open で fail
 - [ ] U50-E03: 無効プロパティ変更で fail
 
 ## 正常系
 
-- U50-01: `asset_prefab_create` → 成功
-- U50-02: `asset_prefab_open` → `component_add(BoxCollider)` → `asset_prefab_save` → `asset_prefab_exit_mode`
-- U50-03: `asset_prefab_instantiate`（`LLMTEST_Cube_Instance`）→ 生成
-- U50-04: `asset_prefab_modify`（`applyToInstances=true`）→ 反映
+- U50-01: `create_prefab` → 成功
+- U50-02: `open_prefab` → `add_component(BoxCollider)` → `save_prefab` → `exit_prefab_mode`
+- U50-03: `instantiate_prefab`（`LLMTEST_Cube_Instance`）→ 生成
+- U50-04: `modify_prefab`（`applyToInstances=true`）→ 反映
 
 ## 異常系
 

--- a/tests/test-mcp-project-settings-tools.md
+++ b/tests/test-mcp-project-settings-tools.md
@@ -8,7 +8,7 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `settings_get` の前後比較（適用前/適用後）。
+- 差分検証: `get_project_settings` の前後比較（適用前/適用後）。
 - 構造検証: 変更対象カテゴリ（player/graphics/quality 等）のキー値が期待どおり変化しているか確認。
 - 参照検証: Quality/Graphics の変更が GameView などに反映されるかは必要に応じて補助。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
@@ -17,16 +17,16 @@
 - 変更前の設定値（例: `vSyncCount`）を必ず保存し、テスト終了時に元の値へ復元する。
 
 チェックリスト（Markdown）
-- [ ] U110-01: settings_get（quality.vSyncCount 確認）
-- [ ] U110-02: settings_update（confirmChanges=true で一時変更）
+- [ ] U110-01: get_project_settings（quality.vSyncCount 確認）
+- [ ] U110-02: update_project_settings（confirmChanges=true で一時変更）
 - [ ] U110-03: 変更確認→復元
 - [ ] U110-E01: confirmChanges=false で fail
 - [ ] U110-E02: 不正値（例: vSyncCount=-1）で fail
 
 ## 正常系
 
-- U110-01: `settings_get`（quality）→ `vSyncCount` を取得
-- U110-02: `settings_update`（`confirmChanges=true`）で一時変更（0↔1）
+- U110-01: `get_project_settings`（quality）→ `vSyncCount` を取得
+- U110-02: `update_project_settings`（`confirmChanges=true`）で一時変更（0↔1）
 - U110-03: 変更確認後に復元
 
 ## 異常系

--- a/tests/test-mcp-references-selection-tools.md
+++ b/tests/test-mcp-references-selection-tools.md
@@ -8,15 +8,15 @@
 前提: 対象 `/LLMTEST_Cube`
 
 チェックリスト（Markdown）
-- [ ] U100-01: analysis_object_references_get（参照情報）
-- [ ] U100-02: editor_selection_manage（set→get）
+- [ ] U100-01: get_object_references（参照情報）
+- [ ] U100-02: manage_selection（set→get）
 - [ ] U100-E01: 存在しない対象で fail
 - [ ] U100-E02: 不正選択パスで fail
 
 ## 正常系
 
-- U100-01: `analysis_object_references_get` → 参照情報が返る
-- U100-02: `editor_selection_manage`（set → get）→ 選択が反映
+- U100-01: `get_object_references` → 参照情報が返る
+- U100-02: `manage_selection`（set → get）→ 選択が反映
 
 ## 異常系
 

--- a/tests/test-mcp-registry-tools.md
+++ b/tests/test-mcp-registry-tools.md
@@ -6,15 +6,15 @@
 - 既存のレジストリ設定には影響を与えない。`recommend`/`list` 等の非破壊操作に限定。
 
 チェックリスト（Markdown）
-- [ ] R10-01: package_registry_config（action=recommend, registry=OpenUPM）→ 推奨スコープ取得
-- [ ] R10-02: package_registry_config（action=get）→ 現在の登録状況取得
+- [ ] R10-01: registry_config（action=recommend, registry=OpenUPM）→ 推奨スコープ取得
+- [ ] R10-02: registry_config（action=get）→ 現在の登録状況取得
 - [ ] R10-E01: 不正 registry 名 → fail
 
 ## 正常系
 
-- R10-01: `package_registry_config`（`action=recommend`, `registry=OpenUPM`）→ 推奨スコープが得られる
-- R10-02: `package_registry_config`（`action=get`）→ 現在のスコープ一覧
+- R10-01: `registry_config`（`action=recommend`, `registry=OpenUPM`）→ 推奨スコープが得られる
+- R10-02: `registry_config`（`action=get`）→ 現在のスコープ一覧
 
 ## 異常系
 
-- R10-E01: `package_registry_config`（未知の `registry`）→ `fail`
+- R10-E01: `registry_config`（未知の `registry`）→ `fail`

--- a/tests/test-mcp-scene-analysis-tools.md
+++ b/tests/test-mcp-scene-analysis-tools.md
@@ -8,23 +8,23 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `analysis_scene_contents_analyze` の前後比較（object counts/memory 推定等）。
-- 構造検証: `gameobject_get_hierarchy` で構成変化を補助確認。
-- 参照検証: 変化対象に対する参照の有無を `analysis_object_references_get` で補助。
+- 差分検証: `analyze_scene_contents` の前後比較（object counts/memory 推定等）。
+- 構造検証: `get_hierarchy` で構成変化を補助確認。
+- 参照検証: 変化対象に対する参照の有無を `get_object_references` で補助。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
 原状回復（必須）・禁止事項:
 - 解析は非破壊。必要に応じて一時オブジェクトを生成した場合は削除。
 
 チェックリスト（Markdown）
-- [ ] SA10-01: analysis_scene_contents_analyze（includeInactive=true, groupByType=true）
-- [ ] SA10-02: gameobject_get_hierarchy（nameOnly=true, maxObjects=100）
+- [ ] SA10-01: analyze_scene_contents（includeInactive=true, groupByType=true）
+- [ ] SA10-02: get_hierarchy（nameOnly=true, maxObjects=100）
 - [ ] SA10-E01: パラメータ不正（maxObjects<0 等）で fail
 
 ## 正常系
 
-- SA10-01: `analysis_scene_contents_analyze` → 種別ごとの集計が取得できる
-- SA10-02: `gameobject_get_hierarchy`（nameOnly, maxObjects）→ ヒエラルキー取得
+- SA10-01: `analyze_scene_contents` → 種別ごとの集計が取得できる
+- SA10-02: `get_hierarchy`（nameOnly, maxObjects）→ ヒエラルキー取得
 
 ## 異常系
 

--- a/tests/test-mcp-scene-tools.md
+++ b/tests/test-mcp-scene-tools.md
@@ -8,8 +8,8 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `scene_info_get`/`gameobject_get_hierarchy` で実行前後のスナップショットを取得し比較（追加/削除/ロード状態）。
-- 構造検証: `scene_list` の一覧変化で確認。
+- 差分検証: `get_scene_info`/`get_hierarchy` で実行前後のスナップショットを取得し比較（追加/削除/ロード状態）。
+- 構造検証: `list_scenes` の一覧変化で確認。
 - 参照検証: 必要に応じて対象シーン名の検索・一致件数で確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
@@ -20,7 +20,7 @@
 
 前提・共通ルール:
 - 禁止: UnityMCP 以外のコマンド・独自スクリプトで操作しない。
-- 使用ツール: `scene_create`, `scene_info_get`, `scene_list`, `scene_save`。
+- 使用ツール: `create_scene`, `get_scene_info`, `list_scenes`, `save_scene`。
 
 原状回復（必須）・禁止事項:
 - 作成したシーンはテスト内で保存後、必要に応じて削除または閉じる。既存シーンの変更は行わない。
@@ -29,23 +29,23 @@
 前提: 新規シーン名 `LLMTEST_Scene`
 
 チェックリスト（Markdown）
-- [ ] U10-01: scene_create（loadScene=true）
-- [ ] U10-02: scene_info_get（現在シーンが LLMTEST_Scene）
-- [ ] U10-03: scene_list（LLMTEST_Scene を含む）
-- [ ] U10-04: scene_save（保存確認）
+- [ ] U10-01: create_scene（loadScene=true）
+- [ ] U10-02: get_scene_info（現在シーンが LLMTEST_Scene）
+- [ ] U10-03: list_scenes（LLMTEST_Scene を含む）
+- [ ] U10-04: save_scene（保存確認）
 - [ ] U10-E01: 重複作成はエラー or skip
 - [ ] U10-E02: 無効名でバリデーションエラー
-- [ ] U10-E03: 存在しないシーンで scene_info_get は fail
+- [ ] U10-E03: 存在しないシーンで get_scene_info は fail
 
 ## 正常系
 
-- U10-01: `scene_create`（`loadScene=true`）→ 成功/ロード済
-- U10-02: `scene_info_get` → 現在シーンが `LLMTEST_Scene`
-- U10-03: `scene_list` → `LLMTEST_Scene` を含む
-- U10-04: `scene_save` → 保存確認
+- U10-01: `create_scene`（`loadScene=true`）→ 成功/ロード済
+- U10-02: `get_scene_info` → 現在シーンが `LLMTEST_Scene`
+- U10-03: `list_scenes` → `LLMTEST_Scene` を含む
+- U10-04: `save_scene` → 保存確認
 
 ## 異常系
 
 - U10-E01: 重複作成 → エラーまたは `skip`
 - U10-E02: 無効名 → バリデーションエラー
-- U10-E03: 存在しないシーン指定で `scene_info_get` → `fail`
+- U10-E03: 存在しないシーン指定で `get_scene_info` → `fail`

--- a/tests/test-mcp-ui-tools.md
+++ b/tests/test-mcp-ui-tools.md
@@ -8,8 +8,8 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `ui_get_element_state` で操作前後の状態（interactable/value/visible 等）を比較。
-- 構造検証: `ui_find_elements` の列挙結果の変化で確認。
+- 差分検証: `get_ui_element_state` で操作前後の状態（interactable/value/visible 等）を比較。
+- 構造検証: `find_ui_elements` の列挙結果の変化で確認。
 - 参照検証: 対象 `elementPath` の一致件数や有効/無効の切り替わりで確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
@@ -20,7 +20,7 @@
 
 前提・共通ルール:
 - 禁止: UnityMCP 以外のコマンド・独自スクリプトで操作しない。
-- 使用ツール: `ui_find_elements`, `ui_get_element_state`, `ui_click_element`, `ui_set_element_value`。
+- 使用ツール: `find_ui_elements`, `get_ui_element_state`, `click_ui_element`, `set_ui_element_value`。
 - 推奨シーン: `UnityMCPServer/Assets/Scenes/MCP_UI_AllSystems_TestScene.unity`（uGUI/UI Toolkit/IMGUI を同時に検証可能）
 - 代表 `elementPath` 例:
   - uGUI: `/Canvas/UGUI_Panel/UGUI_Button`
@@ -31,16 +31,16 @@
 - 値設定やトグル変更を行った場合は、終了時に元の値に戻す。テスト専用 UI を対象にすることが望ましい。
 
 チェックリスト（Markdown）
-- [ ] U140-01: ui_find_elements（Button 等）
-- [ ] U140-02: ui_get_element_state（interactable 等）
-- [ ] U140-03: ui_click_element / ui_set_element_value（反映確認）
+- [ ] U140-01: find_ui_elements（Button 等）
+- [ ] U140-02: get_ui_element_state（interactable 等）
+- [ ] U140-03: click_ui_element / set_ui_element_value（反映確認）
 - [ ] U140-E01: 不正 elementPath で fail
 
 ## 正常系（UI が存在する場合）
 
-- U140-01: `ui_find_elements`（`Button` 等）→ 列挙
-- U140-02: `ui_get_element_state` → 状態取得
-- U140-03: `ui_click_element` / `ui_set_element_value` → 操作成功
+- U140-01: `find_ui_elements`（`Button` 等）→ 列挙
+- U140-02: `get_ui_element_state` → 状態取得
+- U140-03: `click_ui_element` / `set_ui_element_value` → 操作成功
 
 ## 異常系
 

--- a/tests/test-mcp-windows-tools.md
+++ b/tests/test-mcp-windows-tools.md
@@ -8,8 +8,8 @@
 - 各ケースの details には `targetPaths: [<相対パス>...]` を付記（単一でも配列）。
 
 観測不能時の二次検証（エビデンス・エスカレーション）
-- 差分検証: `editor_windows_manage(action=get_state)` の前後比較（フォーカス/可視状態/配置）。
-- 構造検証: `editor_windows_manage(action=get)` の一覧に対象が存在/消失していること。
+- 差分検証: `manage_windows(action=get_state)` の前後比較（フォーカス/可視状態/配置）。
+- 構造検証: `manage_windows(action=get)` の一覧に対象が存在/消失していること。
 - 参照検証: ターゲット windowType の一意/複数性を確認。
 - なお判定不能時のみ `skip（OBSERVATION_GAP）`。
 
@@ -20,23 +20,23 @@
 
 前提・共通ルール:
 - 禁止: UnityMCP 以外のコマンド・独自スクリプトで操作しない。
-- 使用ツール: `editor_windows_manage`, `editor_tools_manage`。
+- 使用ツール: `manage_windows`, `manage_tools`。
 
 原状回復（必須）・禁止事項:
 - フォーカス操作などの状態変更は、終了時に元のウィンドウ状態へ戻すか影響が出ない構成で実行。
 
 チェックリスト（Markdown）
-- [ ] U150-01: editor_windows_manage（action=get, includeHidden=true）
-- [ ] U150-02: editor_tools_manage（action=get）
-- [ ] U150-E01: editor_windows_manage（focus, 不在 windowType）で fail
-- [ ] U150-E02: editor_tools_manage（activate, 不明 toolName）で fail
+- [ ] U150-01: manage_windows（action=get, includeHidden=true）
+- [ ] U150-02: manage_tools（action=get）
+- [ ] U150-E01: manage_windows（focus, 不在 windowType）で fail
+- [ ] U150-E02: manage_tools（activate, 不明 toolName）で fail
 
 ## 正常系
 
-- U150-01: `editor_windows_manage`（`action=get`, `includeHidden=true`）→ 一覧
-- U150-02: `editor_tools_manage`（`action=get`）→ 一覧
+- U150-01: `manage_windows`（`action=get`, `includeHidden=true`）→ 一覧
+- U150-02: `manage_tools`（`action=get`）→ 一覧
 
 ## 異常系
 
-- U150-E01: `editor_windows_manage` フォーカス（存在しない `windowType`）→ `fail`
-- U150-E02: `editor_tools_manage` activate（不明 `toolName`）→ `fail`
+- U150-E01: `manage_windows` フォーカス（存在しない `windowType`）→ `fail`
+- U150-E02: `manage_tools` activate（不明 `toolName`）→ `fail`


### PR DESCRIPTION
- .claude-plugin/skills を .claude/skills と同期し、旧ツール名（scene_create/ui_* 等）を新ツール名（create_scene/find_ui_elements 等）へ統一\n- tests/*.md の手順書/チェックリストも同様に更新\n\n検証: npm run test:ci --workspace=mcp-server