### PR TITLE
fix: 旧ツール名の漏れを解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,14 +443,14 @@
 
 ### Features
 
-* add editor_quit tool ([b8908b5](https://github.com/akiojin/unity-mcp-server/commit/b8908b5e90f953c77a9de17c978a97df64e166cc))
-* add quit_editor command for editor_quit tool ([5495b74](https://github.com/akiojin/unity-mcp-server/commit/5495b7455e77a7f5bfe8cd78b30a843d53dfaa4e))
+* add quit_editor tool ([b8908b5](https://github.com/akiojin/unity-mcp-server/commit/b8908b5e90f953c77a9de17c978a97df64e166cc))
+* add quit_editor command for quit_editor tool ([5495b74](https://github.com/akiojin/unity-mcp-server/commit/5495b7455e77a7f5bfe8cd78b30a843d53dfaa4e))
 * **test:** persist run state and add watchdog coverage ([278e024](https://github.com/akiojin/unity-mcp-server/commit/278e02499a3defa5224fb1a5027c4b62563eabb8))
 
 
 ### Bug Fixes
 
-* dedupe editor_quit handler registration ([5701c7f](https://github.com/akiojin/unity-mcp-server/commit/5701c7ffe561da69101a843e3bbebef663700deb))
+* dedupe quit_editor handler registration ([5701c7f](https://github.com/akiojin/unity-mcp-server/commit/5701c7ffe561da69101a843e3bbebef663700deb))
 * delay quit_editor until response is sent ([49f3b4a](https://github.com/akiojin/unity-mcp-server/commit/49f3b4a8408d42ba3767d9c3be6d3ee90ef0a995))
 
 ## [2.37.2](https://github.com/akiojin/unity-mcp-server/compare/v2.37.1...v2.37.2) (2025-11-14)
@@ -465,7 +465,7 @@
 
 ### Bug Fixes
 
-* enforce prefab path requirement in component_field_set schema ([b04fa68](https://github.com/akiojin/unity-mcp-server/commit/b04fa6875776bd4e68956015c5a53483133e3770))
+* enforce prefab path requirement in set_component_field schema ([b04fa68](https://github.com/akiojin/unity-mcp-server/commit/b04fa6875776bd4e68956015c5a53483133e3770))
 
 ## [2.37.0](https://github.com/akiojin/unity-mcp-server/compare/v2.36.3...v2.37.0) (2025-11-12)
 

--- a/UnityMCPServer/Packages/unity-mcp-server/Editor/Handlers/TestExecutionHandler.cs
+++ b/UnityMCPServer/Packages/unity-mcp-server/Editor/Handlers/TestExecutionHandler.cs
@@ -221,33 +221,33 @@ namespace UnityMCPServer.Handlers
 
                     SaveRunState("running");
 
-                    return new
-                    {
-                        status = "running",
-                        message = "Test execution in progress",
-                        testMode = currentTestMode,
-                        runId = currentRunId,
-                        source = "test_run",
-                        elapsedSeconds = runStartedAtUtc.HasValue ? (DateTime.UtcNow - runStartedAtUtc.Value).TotalSeconds : (double?)null
-                    };
-                }
+	                    return new
+	                    {
+	                        status = "running",
+	                        message = "Test execution in progress",
+	                        testMode = currentTestMode,
+	                        runId = currentRunId,
+	                        source = "run_tests",
+	                        elapsedSeconds = runStartedAtUtc.HasValue ? (DateTime.UtcNow - runStartedAtUtc.Value).TotalSeconds : (double?)null
+	                    };
+	                }
 
                 if (currentCollector == null)
                 {
                     var persisted = LoadRunState();
                     if (persisted != null && persisted.status == "running")
                     {
-                        return new
-                        {
-                            status = "running",
-                            message = "Test execution in progress (persisted state)",
-                            testMode = persisted.testMode,
-                            runId = persisted.runId,
-                            source = "test_run",
-                            persisted = true,
-                            elapsedSeconds = persisted.runStartedAt.HasValue ? (DateTime.UtcNow - persisted.runStartedAt.Value).TotalSeconds : (double?)null
-                        };
-                    }
+	                        return new
+	                        {
+	                            status = "running",
+	                            message = "Test execution in progress (persisted state)",
+	                            testMode = persisted.testMode,
+	                            runId = persisted.runId,
+	                            source = "run_tests",
+	                            persisted = true,
+	                            elapsedSeconds = persisted.runStartedAt.HasValue ? (DateTime.UtcNow - persisted.runStartedAt.Value).TotalSeconds : (double?)null
+	                        };
+	                    }
 
                     return new
                     {

--- a/mcp-server/tests/unit/handlers/input/InputBindingRemoveAllToolHandler.test.js
+++ b/mcp-server/tests/unit/handlers/input/InputBindingRemoveAllToolHandler.test.js
@@ -19,7 +19,7 @@ describe('InputBindingRemoveAllToolHandler', () => {
 
   describe('constructor', () => {
     it('should initialize with correct properties', () => {
-      assert.equal(handler.name, 'remove_input_binding_all');
+      assert.equal(handler.name, 'remove_all_bindings');
       assert.ok(handler.description);
       assert.ok(handler.description.includes('Binding'));
     });


### PR DESCRIPTION
ツール名統一（MCPツール名=Unity command type）後に残っていた旧名表記を除去します。\n\n- CHANGELOG の旧名（editor_quit/component_field_set）を新名へ\n- Unity側 get_test_status の source 表記を run_tests へ\n- remove_all_bindings の unit test 期待値を更新\n\n検証: npm run test:unit --workspace=mcp-server