### PR TITLE
chore(ci): auto-mergeをリトライして安定化

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,8 +26,30 @@ jobs:
         )
       )
     steps:
-      - name: Enable auto-merge
+      - name: Enable auto-merge (with retry)
         env:
           GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr merge "${{ github.event.pull_request.number }}" --auto --merge --repo "${{ github.repository }}"
+          set -euo pipefail
+
+          for i in $(seq 1 60); do
+            echo "Attempt $i: enable auto-merge for #$PR_NUMBER"
+
+            if gh pr merge "$PR_NUMBER" --auto --merge --repo "$REPO"; then
+              echo "Auto-merge enabled"
+              exit 0
+            fi
+
+            mergeable=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq .mergeable || echo "UNKNOWN")
+            if [ "$mergeable" = "CONFLICTING" ]; then
+              echo "PR has merge conflicts; cannot auto-merge" >&2
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Failed to enable auto-merge after 10 minutes" >&2
+          exit 1


### PR DESCRIPTION
main向けrelease-please PRは必須チェックが少ない関係で mergeStateStatus が UNSTABLE になりやすく、Auto Merge PR が1回目で失敗することがありました。\n\nAuto Merge PR の  をリトライして、チェック進行中でも最終的に有効化できるようにします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * PR自動マージ機能の信頼性を向上。リトライロジックを導入し、マージ失敗時に最大60回まで自動的に再試行。
  * マージ競合を検出し、適切なエラー通知を提供。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->