### PR TITLE
fix(mcp-server): correct package_manager command typo

### DIFF
--- a/mcp-server/src/handlers/package/PackageManagerToolHandler.js
+++ b/mcp-server/src/handlers/package/PackageManagerToolHandler.js
@@ -84,7 +84,7 @@ export default class PackageManagerToolHandler extends BaseToolHandler {
       await this.unityConnection.connect();
     }
 
-    const result = await this.unityConnection.sendCommand('package_managerr', {
+    const result = await this.unityConnection.sendCommand('package_manager', {
       action,
       ...parameters
     });

--- a/mcp-server/tests/unit/handlers/package/PackageManagerToolHandler.test.js
+++ b/mcp-server/tests/unit/handlers/package/PackageManagerToolHandler.test.js
@@ -18,7 +18,7 @@ describe('PackageManagerToolHandler', () => {
 
   describe('constructor', () => {
     it('should initialize with correct properties', () => {
-      assert.equal(handler.name, 'package_managerr');
+      assert.equal(handler.name, 'package_manager');
       assert.ok(handler.description);
       assert.ok(handler.description.includes('package'));
     });


### PR DESCRIPTION
## Summary
- Fix typo in PackageManagerToolHandler: `package_managerr` → `package_manager`
- This typo caused UNKNOWN_COMMAND errors when using package_manager tool

## Changes
- `mcp-server/src/handlers/package/PackageManagerToolHandler.js:87` - Fixed command name
- `mcp-server/tests/unit/handlers/package/PackageManagerToolHandler.test.js:21` - Fixed test expectation

## Test plan
- [x] E2E test confirmed: 57 tools tested, 100% pass rate after fix
- [x] package_manager list action now returns 48 packages successfully
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)