### PR TITLE
feat(edit_snippet): add skipValidation option for large files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,12 @@ Speckitは要件ディレクトリ（`specs/SPEC-xxxxxxxx/`）のみを作成し
 - アンカーが一意（複数マッチはエラー）
 - 1回のリクエストで最大10箇所まで
 
+**オプション**:
+- `preview`: `true`でファイル書き込みなし、プレビュー返却
+- `skipValidation`: `true`でLSP検証をスキップ（大きなファイルでタイムアウト回避）
+  - 軽量構文チェック（括弧バランス）は引き続き実行される
+  - レスポンスに`validationSkipped: true`が含まれる
+
 **使用例**:
 
 ```javascript
@@ -329,6 +335,22 @@ Speckitは要件ディレクトリ（`specs/SPEC-xxxxxxxx/`）のみを作成し
         "position": "before"
       },
       "newText": "        Validate();\n"
+    }
+  ]
+}
+
+// 大きなファイルでの編集（LSP検証スキップ）
+{
+  "path": "Assets/Scripts/LargeFile.cs",
+  "skipValidation": true,
+  "instructions": [
+    {
+      "operation": "replace",
+      "anchor": {
+        "type": "text",
+        "target": "maxCount = 100"
+      },
+      "newText": "maxCount = 200"
     }
   ]
 }
@@ -410,6 +432,9 @@ Speckitは要件ディレクトリ（`specs/SPEC-xxxxxxxx/`）のみを作成し
 
 **Q: 構文エラーが出る**
 - A: `preview=true` で事前確認。LSP診断結果を確認してから修正
+
+**Q: 大きなファイル（1000行以上）でLSPタイムアウトが発生する**
+- A: `skipValidation=true` でLSP検証をスキップ。軽量構文チェック（括弧バランス）は引き続き実行される
 
 #### ベストプラクティス
 

--- a/mcp-server/src/core/config.js
+++ b/mcp-server/src/core/config.js
@@ -153,7 +153,7 @@ const baseConfig = {
 
   // LSP client defaults
   lsp: {
-    requestTimeoutMs: 60000
+    requestTimeoutMs: 120000
   },
 
   // Indexing (code index) settings


### PR DESCRIPTION
## Summary

大きなC#ファイル（1000行以上）でのLSP検証タイムアウト問題を解決します。

- `skipValidation` オプションを追加（true でLSP検証をスキップ）
- デフォルトのLSPタイムアウトを60秒から120秒に延長
- 軽量構文チェック（括弧バランス）はskipValidation=trueでも実行
- レスポンスに`validationSkipped`フラグを追加
- テスト4件追加（TDD RED/GREENサイクル完了）
- CLAUDE.mdにドキュメント追加

### 使用例

```javascript
{
  "path": "Assets/Scripts/LargeFile.cs",
  "skipValidation": true,
  "instructions": [
    {
      "operation": "replace",
      "anchor": { "type": "text", "target": "maxCount = 100" },
      "newText": "maxCount = 200"
    }
  ]
}
```

## Test plan

- [x] skipValidation=true でLSP検証がスキップされることを確認
- [x] skipValidation=true でも preSyntaxCheck（括弧バランスチェック）は実行される
- [x] skipValidation=false（デフォルト）でLSP検証が実行される
- [x] レスポンスに validationSkipped フラグが含まれる

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)