### PR TITLE
fix(plugin): correct version placement in marketplace and plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "unity-mcp-server",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Claude Code skills for Unity MCP Server. Provides workflow-oriented guidance for C# editing, Scene/GameObject management, PlayMode testing, and Asset management using 108+ Unity automation tools.",
   "owner": {
     "name": "akiojin",

--- a/.claude-plugin/plugins/unity-mcp-server/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugins/unity-mcp-server/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unity-mcp-server",
   "description": "Claude Code skills for Unity MCP Server. Provides workflow-oriented guidance for C# editing, Scene/GameObject management, PlayMode testing, and Asset management using 108+ Unity automation tools.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "akiojin",
     "url": "https://github.com/akiojin"


### PR DESCRIPTION
## Summary
- Corrected version placement between marketplace.json and plugin.json
- marketplace.json now has marketplace version (1.0.0)
- plugin.json now has plugin version (1.0.1)

## Changes
- `marketplace.json`: version 1.0.1 → 1.0.0
- `plugin.json`: version 1.0.0 → 1.0.1

## Test plan
- [ ] Verify plugin loads correctly in Claude Code
- [ ] Verify version is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)