### PR TITLE
refactor(plugin): simplify plugin structure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,9 @@
   "plugins": [
     {
       "name": "unity-mcp-server",
-      "source": "./.claude-plugin/plugins/unity-mcp-server",
       "description": "Claude Code skills for Unity MCP Server. Provides workflow-oriented guidance for C# editing, Scene/GameObject management, PlayMode testing, and Asset management using 108+ Unity automation tools.",
+      "version": "1.0.1",
+      "source": "./.claude-plugin/plugins/unity-mcp-server",
       "category": "development"
     }
   ]

--- a/.claude-plugin/plugins/unity-mcp-server/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugins/unity-mcp-server/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "unity-mcp-server",
-  "description": "Claude Code skills for Unity MCP Server. Provides workflow-oriented guidance for C# editing, Scene/GameObject management, PlayMode testing, and Asset management using 108+ Unity automation tools.",
-  "version": "1.0.1",
-  "author": {
-    "name": "akiojin",
-    "url": "https://github.com/akiojin"
-  }
-}


### PR DESCRIPTION
## Summary
- Simplified Claude Code plugin structure by removing nested plugin.json
- Plugin metadata (version) now lives directly in marketplace.json plugins entry

## Changes
- Removed `.claude-plugin/plugins/unity-mcp-server/.claude-plugin/plugin.json`
- Added `version` field to plugins entry in marketplace.json

## New Structure
```
.claude-plugin/
├── marketplace.json              # Contains plugin version
└── plugins/
    └── unity-mcp-server/
        ├── agents/
        ├── commands/
        └── skills/
```

## Test plan
- [ ] Verify plugin loads correctly in Claude Code
- [ ] Verify all skills/commands/agents are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)