### PR TITLE
chore(docker): remove --ignore-scripts from pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p /root/.claude/tmp
 
 # Node.js依存（corepack + pnpm）
 COPY package.json pnpm-lock.yaml ./
-RUN corepack enable && pnpm install --frozen-lockfile --ignore-scripts
+RUN corepack enable && pnpm install --frozen-lockfile
 
 WORKDIR /unity-mcp-server
 


### PR DESCRIPTION
## Summary
- Dockerfileの`pnpm install`コマンドから`--ignore-scripts`オプションを削除
- パッケージのpostinstallなどのスクリプトが正常に実行されるように修正

## Test plan
- [ ] Docker buildが成功することを確認
- [ ] pnpmインストール時にスクリプトが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)