### PR TITLE
feat(skill): enable Unity MCP Server skills via symlinks

### DIFF
--- a/.claude/agents/unity-helper.md
+++ b/.claude/agents/unity-helper.md
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/agents/unity-helper.md

--- a/.claude/commands/unity-screenshot.md
+++ b/.claude/commands/unity-screenshot.md
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/commands/unity-screenshot.md

--- a/.claude/commands/unity-status.md
+++ b/.claude/commands/unity-status.md
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/commands/unity-status.md

--- a/.claude/skills/unity-asset-management
+++ b/.claude/skills/unity-asset-management
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-asset-management

--- a/.claude/skills/unity-csharp-editing
+++ b/.claude/skills/unity-csharp-editing
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-csharp-editing

--- a/.claude/skills/unity-development
+++ b/.claude/skills/unity-development
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-development

--- a/.claude/skills/unity-editor-imgui-design
+++ b/.claude/skills/unity-editor-imgui-design
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-editor-imgui-design

--- a/.claude/skills/unity-game-ugui-design
+++ b/.claude/skills/unity-game-ugui-design
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-game-ugui-design

--- a/.claude/skills/unity-game-ui-toolkit-design
+++ b/.claude/skills/unity-game-ui-toolkit-design
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-game-ui-toolkit-design

--- a/.claude/skills/unity-playmode-testing
+++ b/.claude/skills/unity-playmode-testing
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-playmode-testing

--- a/.claude/skills/unity-scene-management
+++ b/.claude/skills/unity-scene-management
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-scene-management

--- a/.codex/skills/unity-asset-management
+++ b/.codex/skills/unity-asset-management
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-asset-management

--- a/.codex/skills/unity-csharp-editing
+++ b/.codex/skills/unity-csharp-editing
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-csharp-editing

--- a/.codex/skills/unity-development
+++ b/.codex/skills/unity-development
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-development

--- a/.codex/skills/unity-editor-imgui-design
+++ b/.codex/skills/unity-editor-imgui-design
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-editor-imgui-design

--- a/.codex/skills/unity-game-ugui-design
+++ b/.codex/skills/unity-game-ugui-design
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-game-ugui-design

--- a/.codex/skills/unity-game-ui-toolkit-design
+++ b/.codex/skills/unity-game-ui-toolkit-design
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-game-ui-toolkit-design

--- a/.codex/skills/unity-playmode-testing
+++ b/.codex/skills/unity-playmode-testing
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-playmode-testing

--- a/.codex/skills/unity-scene-management
+++ b/.codex/skills/unity-scene-management
@@ -1,0 +1,1 @@
+../../.claude-plugin/plugins/unity-mcp-server/skills/unity-scene-management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -895,6 +895,55 @@ README.mdにカバレッジバッジを追加する場合：
 
 ---
 
+## Unity MCP Server スキル・コマンド
+
+このプロジェクトでは、Unity開発を効率化するためのスキルとコマンドを提供しています。
+
+### 利用可能なスキル
+
+| スキル名 | 説明 | 使用場面 |
+|---------|------|---------|
+| `unity-development` | 親スキル。アーキテクチャパターン、ツール選択ガイド | Unity開発全般 |
+| `unity-csharp-editing` | C#編集、TDD、リファクタリング | コード編集時 |
+| `unity-scene-management` | シーン・GameObject操作 | シーン構築時 |
+| `unity-asset-management` | プレハブ、マテリアル、Addressables | アセット管理時 |
+| `unity-playmode-testing` | PlayModeテスト、入力シミュレーション | テスト実行時 |
+| `unity-game-ugui-design` | uGUI（Canvas/EventSystem） | ゲームUI実装時 |
+| `unity-game-ui-toolkit-design` | UI Toolkit（Runtime） | モダンUI実装時 |
+| `unity-editor-imgui-design` | IMGUI（EditorWindow/Inspector） | エディタ拡張時 |
+
+### 利用可能なコマンド
+
+| コマンド | 説明 |
+|---------|------|
+| `/unity-status` | Unity Editorの接続状態、シーン情報、コンパイル状態を確認 |
+| `/unity-screenshot` | Game/Scene/Explorerビューのスクリーンショットを撮影 |
+
+### 利用可能なエージェント
+
+| エージェント | 説明 |
+|------------|------|
+| `unity-helper` | 108+のUnityツールを活用した開発支援エージェント |
+
+### スキルの参照方法
+
+スキルは自動的に参照されますが、明示的に呼び出す場合：
+
+```
+Skillツールで unity-development を使用してください
+```
+
+### MCP ツールの命名規則
+
+Unity MCP Server のツールは以下の命名規則に従います：
+
+- `mcp__unity-mcp-server__<category>_<action>`
+- 例: `mcp__unity-mcp-server__gameobject_create`, `mcp__unity-mcp-server__scene_save`
+
+詳細は各スキルのドキュメントを参照してください。
+
+---
+
 ## Hook機能による自動化（Claude Code）
 
 このプロジェクトでは、Claude CodeのHook機能を活用して以下の自動化を実現しています。


### PR DESCRIPTION
## Summary

- シンボリックリンクを使用して `.claude-plugin/` のスキル・コマンド・エージェントを `.claude/` と `.codex/` から参照可能に
- CLAUDE.md に Unity MCP Server スキル・コマンドのドキュメントを追加

## Changes

### .claude/ (Claude Code用)
- `agents/unity-helper.md` → エージェント
- `skills/unity-*` → 8つのスキル
- `commands/unity-screenshot.md`, `commands/unity-status.md` → 2つのコマンド

### .codex/ (Codex用 - スキルのみ)
- `skills/unity-*` → 8つのスキル

### CLAUDE.md
- Unity MCP Server スキル・コマンドセクションを追加

## Test plan
- [ ] `/unity-status` コマンドが動作する
- [ ] `/unity-screenshot` コマンドが動作する
- [ ] `unity-helper` エージェントが Task ツールで利用可能
- [ ] `unity-development` スキルが Skill ツールで利用可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)