### PR TITLE
fix(core): suppress client disconnect transport errors

### DIFF
--- a/UnityMCPServer/Packages/unity-mcp-server/Editor/Core/UnityMCPServer.cs
+++ b/UnityMCPServer/Packages/unity-mcp-server/Editor/Core/UnityMCPServer.cs
@@ -339,6 +339,13 @@ namespace UnityMCPServer.Core
                     }
                 }
             }
+            catch (Exception ex) when (IsClientDisconnected(ex))
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    McpLogger.Log("Client disconnected");
+                }
+            }
             catch (Exception ex)
             {
                 if (!cancellationToken.IsCancellationRequested)
@@ -373,9 +380,55 @@ namespace UnityMCPServer.Core
             }
             catch (Exception ex)
             {
+                if (IsClientDisconnected(ex))
+                {
+                    return;
+                }
+
                 try { McpLogger.LogError($"Send error: {ex}"); } catch { }
                 throw;
             }
+        }
+
+        private static bool IsClientDisconnected(Exception ex)
+        {
+            if (ex is null) return false;
+
+            if (ex is ObjectDisposedException || ex is OperationCanceledException)
+            {
+                return true;
+            }
+
+            if (ex is IOException ioEx && ioEx.Message != null &&
+                ioEx.Message.IndexOf("transport connection", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+
+            var socketError = GetSocketError(ex);
+            return socketError.HasValue && IsSocketDisconnected(socketError.Value);
+        }
+
+        private static SocketError? GetSocketError(Exception ex)
+        {
+            if (ex is SocketException socketEx)
+            {
+                return socketEx.SocketErrorCode;
+            }
+
+            if (ex is IOException ioEx && ioEx.InnerException is SocketException innerSocketEx)
+            {
+                return innerSocketEx.SocketErrorCode;
+            }
+
+            return null;
+        }
+
+        private static bool IsSocketDisconnected(SocketError errorCode)
+        {
+            return errorCode == SocketError.ConnectionAborted ||
+                   errorCode == SocketError.ConnectionReset ||
+                   errorCode == SocketError.Shutdown;
         }
         
         /// <summary>


### PR DESCRIPTION
## Summary

- クライアント接続の切断時に例外をエラー扱いしないように変更し、Issue #390 の再接続時に発生する不要な赤ログを抑制します。
- HandleClientAsync と SendFramedMessage で切断系例外を判定し、切断時は通常終了として扱うことで Unity 側のログノイズを減らします。

## Changes

- UnityMCPServer/Packages/unity-mcp-server/Editor/Core/UnityMCPServer.cs: HandleClientAsync の catch を分割し、切断系例外を識別して LogError を回避する分岐を追加。
- UnityMCPServer/Packages/unity-mcp-server/Editor/Core/UnityMCPServer.cs: SendFramedMessage の例外ハンドリングで、切断系例外を再送不能なエラーとして扱わないように調整。
- UnityMCPServer/Packages/unity-mcp-server/Editor/Core/UnityMCPServer.cs: IsClientDisconnected / GetSocketError / IsSocketDisconnected を追加して、切断判定を共通化。

## Testing

- コミット差分を確認する: commit 3f2f89ebd48230bcaab2c0c35837d69a5dae93fc
Author: Akio Jinsenji <akio-jinsenji@cloud-creative-studios.com>
Date:   Wed Feb 25 16:52:20 2026 +0900

    Handle client disconnect exceptions as normal in Unity MCP server

 .../unity-mcp-server/Editor/Core/UnityMCPServer.cs | 53 ++++++++++++++++++++++
 1 file changed, 53 insertions(+)。
- Unity 側で MCP を起動し、クライアント接続後に切断を発生させ、transport connection 起因の Client handler error が出ないことを再現手順で確認します。

## Related Issues / Links

- #390

## Checklist

- [ ] Tests added/updated — N/A: ログハンドリング既存コードの挙動変更のみのため未追加
- [ ] Lint/format passed (cargo clippy, cargo fmt, svelte-check) — N/A: Unity/C# プロジェクトのため未実行
- [ ] Documentation updated (if user-facing change) — N/A: 非ユーザー向けログ改善のみで未更新
- [ ] Migration/backfill plan included (if schema/data change) — N/A: データ構造変更なし
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — N/A: 非互換変更なし

## Context

- Issue #390 はクライアント切断時に transport connection 由来の例外が赤ログ化される現象が報告されており、本修正は切断を正常終了として扱うことで運用品質を改善します。
